### PR TITLE
Task/api 86 H2 configuration for testing with temporary databases

### DIFF
--- a/.git-secrets-patterns
+++ b/.git-secrets-patterns
@@ -1,3 +1,3 @@
-^spring\.datasource\.url=[^u][^n][^s][^e][^t].*
-^spring\.datasource\.username=[^u][^n][^s][^e][^t].*
-^[a-z.-]+(\.|-)password=[^u][^n][^s][^e][^t].*
+spring\.datasource\.url=.*
+spring\.datasource\.username=.*
+[a-z.-]+(\.|-)password=.*

--- a/.gitallowed
+++ b/.gitallowed
@@ -1,0 +1,3 @@
+spring\.datasource\.url=(unset|\$[A-Z_]+)
+spring\.datasource\.username=(unset|\$[A-Z_]+)
+[a-z.-]+(\.|-)password=(unset|\$[A-Z_]+)

--- a/ids/run-local.sh
+++ b/ids/run-local.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+#
+# This script configures and runs the ID service using an embedded H2 database
+# instead of the MySQL database used in normal situations. The H2 database will
+# will be empty, but is suitable for testing.
+#
+
+cd $(dirname $0)
+
+echo "Running ID service with embedded H2 database"
+
+if [ -z "$HEALTH_APIS_CERT_PASSWORD" ]
+then
+  echo "HEALTH_APIS_CERT_PASSWORD is not set"
+  echo "Attempting to discover it from most frequently used password in local configurations"
+  HEALTH_APIS_CERT_PASSWORD=$(grep -E 'ssl.*password' config/*properties \
+    | cut -d = -f 2 \
+    | uniq -c \
+    | sort -nr \
+    | head -1 \
+    | awk '{print $2}')
+  [ -z $HEALTH_APIS_CERT_PASSWORD ] \
+    && echo "Could not discover SSL keystore password from existing configurations" \
+    && exit 1
+fi
+
+APPLICATION_JAR=$(find target -maxdepth 1 -type f -name "ids-*.jar")
+APPLICATION_CLASS=gov.va.api.health.ids.service.Application
+  
+java \
+  -cp $APPLICATION_JAR:target/h2.jar \
+  -Dloader=$APPLICATION_CLASS \
+  -Dspring.jpa.generate-ddl=true \
+  -Dspring.jpa.hibernate.ddl-auto=create-drop \
+  -Dspring.datasource.driver-class-name=org.h2.Driver \
+  -Dspring.datasource.url=jdbc:h2:mem:whatever  \
+  -Dserver.ssl.key-store=file:target/certs/system/DVP-DVP-NONPROD.jks \
+  -Dserver.ssl.key-store-password=$HEALTH_APIS_CERT_PASSWORD \
+  -Dserver.ssl.key-alias=internal-sys-dev \
+  -Dssl.key-store=file:target/certs/system/DVP-DVP-NONPROD.jks \
+  -Dssl.key-store-password=$HEALTH_APIS_CERT_PASSWORD \
+  -Dssl.client-key-password=$HEALTH_APIS_CERT_PASSWORD \
+  -Dssl.use-trust-store=false \
+  -Dssl.trust-store=file:target/certs/system/DVP-NONPROD-truststore.jks \
+  -Dssl.trust-store-password=$HEALTH_APIS_CERT_PASSWORD \
+  org.springframework.boot.loader.PropertiesLauncher

--- a/ids/run-local.sh
+++ b/ids/run-local.sh
@@ -27,9 +27,19 @@ fi
 
 APPLICATION_JAR=$(find target -maxdepth 1 -type f -name "ids-*.jar")
 APPLICATION_CLASS=gov.va.api.health.ids.service.Application
-  
+
+CLASSPATH=$APPLICATION_JAR:target/h2.jar 
+
+#
+# Deal with windows path which wants semi's. Also make sure there are no spaces by
+# using DOS names.
+#
+shopt -s nocasematch
+[[ "$OS" =~ windows.* ]] && CLASSPATH=$(cygpath --path --dos --mixed "$CLASSPATH") 
+
+
 java \
-  -cp $APPLICATION_JAR:target/h2.jar \
+  -cp "$CLASSPATH" \
   -Dloader=$APPLICATION_CLASS \
   -Dspring.jpa.generate-ddl=true \
   -Dspring.jpa.hibernate.ddl-auto=create-drop \

--- a/ids/src/main/resources/application.properties
+++ b/ids/src/main/resources/application.properties
@@ -8,6 +8,7 @@ spring.datasource.url=unset
 spring.datasource.username=unset
 spring.datasource.password=unset
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=none
 logging.stack-trace-filter=java.lang.reflect.Method, org.apache.catalina, org.springframework.aop, org.springframework.security, org.springframework.transaction, org.springframework.web, org.springframework.cglib, org.springframework.validation.beanvalidation, reactor.core, reactor.ipc, sun.reflect, net.sf.cglib, ByCGLIB, io.netty
 logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID: }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx{full,${logging.stack-trace-filter}}}
 logging.level.com.zaxxer.hikari.HikariDataSource=WARN

--- a/service-starter/pom.xml
+++ b/service-starter/pom.xml
@@ -8,6 +8,9 @@
   </parent>
   <artifactId>service-starter</artifactId>
   <packaging>pom</packaging>
+  <properties>
+    <h2.version>1.4.197</h2.version>
+  </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -22,6 +25,12 @@
       <groupId>gov.va.dvp</groupId>
       <artifactId>lighthouse-keystore</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>${h2.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -63,6 +72,18 @@
             <configuration>
               <outputDirectory>${project.build.directory}/certs</outputDirectory>
               <includeArtifactIds>lighthouse-keystore</includeArtifactIds>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-h2</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <includeArtifactIds>h2</includeArtifactIds>
+              <stripVersion>true</stripVersion>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
- Updates secrets to discover spring passwords when used in scripts
- Updates to allowed patterns so that variables can be used, e.g. `password=$WOW_SECRET`
- H2 database library is automatically added to the target directory for easy access
- `run-local.sh` test script for launching `ids` using an ephemeral H2 database