### PR TITLE
Task/api 87 ids registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ backed by information from the Corporate Data Warehouse.
 
 ###### Health API applications
 ![applications](src/plantuml/apps.png)
+- argonaut - Argonaut-compliant experience API
+- mr-anderson - Corporate Data Warehouse access system API
+- [ids](ids/README.md) - An identity mapping service system API
 
 ----
 
@@ -30,19 +33,29 @@ backed by information from the Corporate Data Warehouse.
   with [Find Security Bugs](http://find-sec-bugs.github.io/) extensions
 - Enforces Git branch naming conventions to support Jira integration
 
-
 The above build steps can be skipped for use with IDE launch support by disabling the
 _standard_ profile, e.g. `mvn -P'!standard' package`
 
-###### Configuration
-The spring application requires an [external configuration](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html) which can be provided by a teammate.
-
 #### git-secrets
 git-secrets must be installed and configured to scan for AWS entries and the patterns in
-[.git-secrets-patterns](.git-secrets-patterns).
-The [init-git-secrets.sh](src/scripts/init-git-secrets.sh) can be used to simply set up.
+[.git-secrets-patterns](.git-secrets-patterns). Exclusions are managed in 
+[.gitallowed](.gitallowed).
+The [init-git-secrets.sh](src/scripts/init-git-secrets.sh) script can be used to simply set up.
 
 > ###### ⚠ Mac users
 > If using [Homebrew](https://brew.sh/), use `brew install --HEAD git-secrets` as decribed
 > by [this post](https://github.com/awslabs/git-secrets/issues/65#issuecomment-416382565) to
 > avoid issues committing multiple files.
+
+
+----
+
+## Running
+
+###### Configuration
+The spring application requires an 
+[external configuration](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html)
+for environment specific information, such as database connection URLs. In production or 
+production-like environments, configuration is stored in AWS S3 buckets. In local developer
+environments, configuration can be `config/` directories that are not maintained in Git. See
+a teammate for connection details to shared databases, etc.

--- a/ids-api/pom.xml
+++ b/ids-api/pom.xml
@@ -19,6 +19,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/ids-api/src/main/java/gov/va/api/health/ids/api/Registration.java
+++ b/ids-api/src/main/java/gov/va/api/health/ids/api/Registration.java
@@ -2,6 +2,8 @@ package gov.va.api.health.ids.api;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Singular;
 import lombok.Value;
@@ -10,6 +12,6 @@ import lombok.Value;
 @Builder
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class Registration {
-  String uuid;
-  @Singular List<ResourceIdentity> resourceIdentities;
+  @NotBlank String uuid;
+  @Singular @Valid List<ResourceIdentity> resourceIdentities;
 }

--- a/ids-api/src/main/java/gov/va/api/health/ids/api/ResourceIdentity.java
+++ b/ids-api/src/main/java/gov/va/api/health/ids/api/ResourceIdentity.java
@@ -1,6 +1,7 @@
 package gov.va.api.health.ids.api;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Value;
 
@@ -8,7 +9,7 @@ import lombok.Value;
 @Builder(toBuilder = true)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class ResourceIdentity {
-  String identifier;
-  String system;
-  String resource;
+  @NotBlank String identifier;
+  @NotBlank String system;
+  @NotBlank String resource;
 }

--- a/ids/README.md
+++ b/ids/README.md
@@ -1,0 +1,49 @@
+# ids - Identity Service
+
+The ID service provides a mechanism to translate identifiers that should remain internal or secret
+to the system with equivalent Identities that are public. 
+
+## Data Model
+
+_Resource Identity_
+- Consists of a system, resource type, and an identity.
+- The _identity_ is unique for a given system and resource combination. 
+
+_Registration_
+- Consists of a generated UUID, and list of resource identities.
+- The generated UUID will be considered the public ID.
+- ⚠ The list of resource identities currently contains only one item. This structure
+  will eventually support associated system, e.g. CDW and Cerner.
+
+
+## Behavior
+
+```
+GIVEN a list of unregistered resource identities 
+WHEN a register request is made,
+THEN a 201 response will be returned with a list of registrations, one per given resource identity.
+
+The UUID will be considered public and can be used to perform lookup requests in future calls.
+```
+
+```
+Registration is idempotent. 
+GIVEN a list of previously registered resource identities,
+WHEN a register request is made, 
+THEN a 201 response will be returned with a list of previously registered registrations. 
+
+The UUID for the resource identity is not regenerated
+Duplicate resource identities are not associated with the UUID.
+```
+
+```
+GIVEN a previously registered public ID,
+WHEN a lookup request is made,
+THEN a 200 response is returned with all registered identities as the body.
+```
+
+```
+GIVEN a unregistered public ID,
+WHEN a lookup request is made,
+THEN a 404 response is returned.
+```

--- a/ids/demo.sh
+++ b/ids/demo.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+[ -z "$IDS_URL" ] && IDS_URL=https://localhost:8089
+
+echo "Registering patient ID"
+curl -sk \
+  -H "Content-Type: application/json" \
+  -d '[{"system":"CDW","resource":"PATIENT","identifier":"185601V82529"}]' \
+  $IDS_URL/api/v1/ids \
+  | jq .
+
+echo -e "\nLooking up patient ID"
+curl -sk $IDS_URL/api/v1/ids/c1b51d94-0ae0-526a-8a3b-6ae673991e10 | jq .

--- a/ids/pom.xml
+++ b/ids/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>gov.va.api.health</groupId>
@@ -11,7 +13,8 @@
   <packaging>jar</packaging>
   <properties>
     <mysql-connector-java.version>6.0.6</mysql-connector-java.version>
-    <jacoco.coverage>0.93</jacoco.coverage>
+    <jacoco.coverage>0.94</jacoco.coverage>
+    <java-uuid-generator.version>3.1.5</java-uuid-generator.version>
   </properties>
   <dependencies>
     <dependency>
@@ -31,6 +34,11 @@
       <groupId>gov.va.api.health</groupId>
       <artifactId>ids-api</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.uuid</groupId>
+      <artifactId>java-uuid-generator</artifactId>
+      <version>${java-uuid-generator.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/ids/run-local.sh
+++ b/ids/run-local.sh
@@ -8,6 +8,9 @@
 
 cd $(dirname $0)
 
+set -e
+mvn clean package -DskipTests -P'!standard'
+
 echo "Running ID service with embedded H2 database"
 
 if [ -z "$HEALTH_APIS_CERT_PASSWORD" ]

--- a/ids/src/main/java/gov/va/api/health/ids/service/controller/ErrorResponse.java
+++ b/ids/src/main/java/gov/va/api/health/ids/service/controller/ErrorResponse.java
@@ -1,0 +1,29 @@
+package gov.va.api.health.ids.service.controller;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+/** The error response is the payload returned to the caller should a failure occur. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class ErrorResponse {
+  long timestamp;
+  String type;
+  String message;
+
+  /** Create a new error response based on the given exception. */
+  public static ErrorResponse of(@NonNull Exception e) {
+    return ErrorResponse.builder()
+        .timestamp(System.currentTimeMillis())
+        .type(e.getClass().getSimpleName())
+        .message(e.getMessage())
+        .build();
+  }
+}

--- a/ids/src/main/java/gov/va/api/health/ids/service/controller/IdServiceHomeController.java
+++ b/ids/src/main/java/gov/va/api/health/ids/service/controller/IdServiceHomeController.java
@@ -21,7 +21,7 @@ import org.springframework.web.reactive.function.server.ServerResponse;
 @Controller
 public class IdServiceHomeController {
 
-  private static YAMLMapper yamlMapper = new YAMLMapper();
+  private static final YAMLMapper MAPPER = new YAMLMapper();
 
   @Value("classpath:/api-v1.yaml")
   private Resource openapi;
@@ -48,7 +48,7 @@ public class IdServiceHomeController {
   @GetMapping(value = "/openapi.json", produces = "application/json")
   @ResponseBody
   public Object openapiJson() throws IOException {
-    return IdServiceHomeController.yamlMapper.readValue(openapiContent(), Object.class);
+    return IdServiceHomeController.MAPPER.readValue(openapiContent(), Object.class);
   }
 
   @Bean

--- a/ids/src/main/java/gov/va/api/health/ids/service/controller/IdServiceV1ApiController.java
+++ b/ids/src/main/java/gov/va/api/health/ids/service/controller/IdServiceV1ApiController.java
@@ -1,9 +1,11 @@
 package gov.va.api.health.ids.service.controller;
 
+import gov.va.api.health.ids.api.Registration;
 import gov.va.api.health.ids.api.ResourceIdentity;
 import gov.va.api.health.ids.service.controller.impl.ResourceIdentityDetail;
 import gov.va.api.health.ids.service.controller.impl.ResourceIdentityDetailRepository;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
 import javax.validation.constraints.Pattern;
@@ -11,9 +13,11 @@ import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,13 +31,12 @@ import org.springframework.web.server.ServerWebExchange;
 public class IdServiceV1ApiController {
 
   private final ResourceIdentityDetailRepository repository;
+  private final UuidGenerator uuidGenerator;
 
-  /** Implementation of /v1/ids/{publicId}. See api-v1.yaml. */
+  /** Implementation of GET /v1/ids/{publicId}. See api-v1.yaml. */
   @RequestMapping(
     value = "/v1/ids/{publicId}",
-    produces = {
-      "application/json",
-    },
+    produces = {"application/json"},
     method = RequestMethod.GET
   )
   @SneakyThrows
@@ -52,4 +55,57 @@ public class IdServiceV1ApiController {
 
     return ResponseEntity.ok().body(identities);
   }
+
+  /** Implementation of POST /v1/ids. See api-v1.yaml. */
+  @RequestMapping(
+    value = "v1/ids",
+    produces = {"application/json"},
+    consumes = {"application/json"},
+    method = RequestMethod.POST
+  )
+  public ResponseEntity<List<Registration>> register(
+      @Valid @RequestBody List<ResourceIdentity> identities) {
+
+    List<Registration> registrations =
+        identities.stream().map(this::toRegistration).collect(Collectors.toList());
+
+    List<ResourceIdentityDetail> newRegistrations =
+        registrations
+            .stream()
+            .filter(this::isNotRegistered)
+            .map(this::toDatabaseEntry)
+            .collect(Collectors.toList());
+
+    log.info("Register {} entries ({} are new)", identities.size(), newRegistrations.size());
+    repository.saveAll(newRegistrations);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(registrations);
+  }
+
+  private boolean isNotRegistered(Registration registration) {
+    return repository.findByUuid(registration.uuid()).isEmpty();
+  }
+
+  private Registration toRegistration(ResourceIdentity resourceIdentity) {
+    return Registration.builder()
+        .uuid(uuidGenerator.apply(resourceIdentity))
+        .resourceIdentity(resourceIdentity)
+        .build();
+  }
+
+  private ResourceIdentityDetail toDatabaseEntry(Registration registration) {
+    ResourceIdentity resourceIdentity = registration.resourceIdentities().get(0);
+    return ResourceIdentityDetail.builder()
+        .uuid(registration.uuid())
+        .system(resourceIdentity.system())
+        .resource(resourceIdentity.resource())
+        .identifier(resourceIdentity.identifier())
+        .build();
+  }
+
+  /**
+   * Generates consistent public UUIDs for a given resource identity. This function should be
+   * deterministic. Failure to do so will result in multiple registrations for the same identity.
+   */
+  public interface UuidGenerator extends Function<ResourceIdentity, String> {}
 }

--- a/ids/src/main/java/gov/va/api/health/ids/service/controller/WebExceptionHandler.java
+++ b/ids/src/main/java/gov/va/api/health/ids/service/controller/WebExceptionHandler.java
@@ -1,0 +1,43 @@
+package gov.va.api.health.ids.service.controller;
+
+import gov.va.api.health.ids.api.IdentityService.UnknownIdentity;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Exceptions that escape the rest controllers will be processed by this handler. It will convert
+ * exception into different HTTP status codes and produce an error response payload.
+ */
+@RestControllerAdvice
+@RequestMapping(produces = {"application/json"})
+@Slf4j
+public class WebExceptionHandler {
+
+  private ErrorResponse responseFor(Exception e) {
+    ErrorResponse response = ErrorResponse.of(e);
+    log.error("{}: {}", response.type(), response.message(), e);
+    return response;
+  }
+
+  @ExceptionHandler({UnknownIdentity.class})
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public ErrorResponse handleNotFound(Exception e) {
+    return responseFor(e);
+  }
+
+  @ExceptionHandler({javax.validation.ConstraintViolationException.class})
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorResponse handleBadRequest(Exception e) {
+    return responseFor(e);
+  }
+
+  @ExceptionHandler({Exception.class})
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  public ErrorResponse handleSnafu(Exception e) {
+    return responseFor(e);
+  }
+}

--- a/ids/src/main/java/gov/va/api/health/ids/service/controller/impl/ResourceIdentityDetail.java
+++ b/ids/src/main/java/gov/va/api/health/ids/service/controller/impl/ResourceIdentityDetail.java
@@ -9,6 +9,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.Max;
+import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,13 +22,13 @@ import lombok.ToString;
  *
  * <pre>
  *   CREATE TABLE `resource_identity_detail` (
- *   `id` int(11) NOT NULL AUTO_INCREMENT,
+ *   `pk` int(11) NOT NULL AUTO_INCREMENT,
  *   `identifier` varchar(45) NOT NULL,
  *   `station_identifier` varchar(45) DEFAULT NULL,
  *   `uuid` varchar(45) NOT NULL,
  *   `system` varchar(45) NOT NULL,
  *   `resource` varchar(45) NOT NULL,
- *   PRIMARY KEY (`id`),
+ *   PRIMARY KEY (`pk`),
  *   UNIQUE KEY `uuid_UNIQUE` (`uuid`),
  *   UNIQUE KEY `station_urn_UNIQUE` (`station_identifier`,`identifier`)
  * ) ENGINE=InnoDB AUTO_INCREMENT=3353 DEFAULT CHARSET=utf8;
@@ -45,11 +46,12 @@ public class ResourceIdentityDetail {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "id")
-  int id;
+  @Column(name = "pk")
+  int pk;
 
   @Column(name = "identifier")
   @Max(45)
+  @NotBlank
   String identifier;
 
   @Column(name = "station_identifier")
@@ -58,14 +60,17 @@ public class ResourceIdentityDetail {
 
   @Column(name = "uuid")
   @Max(45)
+  @NotBlank
   String uuid;
 
   @Column(name = "system")
   @Max(45)
+  @NotBlank
   String system;
 
   @Column(name = "resource")
   @Max(45)
+  @NotBlank
   String resource;
 
   @Override
@@ -77,12 +82,12 @@ public class ResourceIdentityDetail {
       return false;
     }
     ResourceIdentityDetail that = (ResourceIdentityDetail) o;
-    return id == that.id;
+    return pk == that.pk;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id);
+    return Objects.hash(pk);
   }
 
   /** Convert this database entity into a more friendly, non-JPA form. */

--- a/ids/src/main/java/gov/va/api/health/ids/service/controller/impl/ResourceIdentityDetail.java
+++ b/ids/src/main/java/gov/va/api/health/ids/service/controller/impl/ResourceIdentityDetail.java
@@ -22,13 +22,13 @@ import lombok.ToString;
  *
  * <pre>
  *   CREATE TABLE `resource_identity_detail` (
- *   `pk` int(11) NOT NULL AUTO_INCREMENT,
+ *   `id` int(11) NOT NULL AUTO_INCREMENT,
  *   `identifier` varchar(45) NOT NULL,
  *   `station_identifier` varchar(45) DEFAULT NULL,
  *   `uuid` varchar(45) NOT NULL,
  *   `system` varchar(45) NOT NULL,
  *   `resource` varchar(45) NOT NULL,
- *   PRIMARY KEY (`pk`),
+ *   PRIMARY KEY (`id`),
  *   UNIQUE KEY `uuid_UNIQUE` (`uuid`),
  *   UNIQUE KEY `station_urn_UNIQUE` (`station_identifier`,`identifier`)
  * ) ENGINE=InnoDB AUTO_INCREMENT=3353 DEFAULT CHARSET=utf8;

--- a/ids/src/main/java/gov/va/api/health/ids/service/controller/impl/ResourceIdentityDetail.java
+++ b/ids/src/main/java/gov/va/api/health/ids/service/controller/impl/ResourceIdentityDetail.java
@@ -46,7 +46,7 @@ public class ResourceIdentityDetail {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "pk")
+  @Column(name = "id")
   int pk;
 
   @Column(name = "identifier")

--- a/ids/src/main/java/gov/va/api/health/ids/service/controller/impl/Type5UuidGenerator.java
+++ b/ids/src/main/java/gov/va/api/health/ids/service/controller/impl/Type5UuidGenerator.java
@@ -1,0 +1,31 @@
+package gov.va.api.health.ids.service.controller.impl;
+
+import com.fasterxml.uuid.Generators;
+import gov.va.api.health.ids.api.ResourceIdentity;
+import gov.va.api.health.ids.service.controller.IdServiceV1ApiController.UuidGenerator;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Generates a UUID in a deterministic approach using a seed UUID plus the resource type and
+ * identifier.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Service
+public class Type5UuidGenerator implements UuidGenerator {
+
+  @Value("${uuid.seed}")
+  private String seed;
+
+  @Override
+  public String apply(@NonNull ResourceIdentity resourceIdentity) {
+    return Generators.nameBasedGenerator(UUID.fromString(seed))
+        .generate(resourceIdentity.resource() + ":" + resourceIdentity.identifier())
+        .toString();
+  }
+}

--- a/ids/src/main/resources/application.properties
+++ b/ids/src/main/resources/application.properties
@@ -16,3 +16,4 @@ management.endpoint.env.enabled=true
 management.endpoint.metrics.enabled=true
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=health,info,env,metrics,prometheus
+uuid.seed=a6c6bfdf-2ebb-5e8a-b69b-696ccd8731d9

--- a/ids/src/test/java/gov/va/api/health/ids/service/controller/ErrorResponseTest.java
+++ b/ids/src/test/java/gov/va/api/health/ids/service/controller/ErrorResponseTest.java
@@ -1,0 +1,24 @@
+package gov.va.api.health.ids.service.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.va.api.health.autoconfig.configuration.JacksonConfig;
+import lombok.SneakyThrows;
+import org.junit.Test;
+
+public class ErrorResponseTest {
+  @SneakyThrows
+  private <T> T roundTrip(T object) {
+    ObjectMapper mapper = new JacksonConfig().objectMapper();
+    String json = mapper.writeValueAsString(object);
+    Object evilTwin = mapper.readValue(json, object.getClass());
+    assertThat(evilTwin).isEqualTo(object);
+    return object;
+  }
+
+  @Test
+  public void errorResponse() {
+    roundTrip(ErrorResponse.of(new RuntimeException("fugazi")));
+  }
+}

--- a/ids/src/test/java/gov/va/api/health/ids/service/controller/IdServiceHomeControllerTest.java
+++ b/ids/src/test/java/gov/va/api/health/ids/service/controller/IdServiceHomeControllerTest.java
@@ -2,22 +2,19 @@ package gov.va.api.health.ids.service.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import gov.va.api.health.ids.service.controller.impl.ResourceIdentityDetailRepository;
 import java.nio.charset.StandardCharsets;
 import lombok.SneakyThrows;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.util.StreamUtils;
 
 @RunWith(SpringRunner.class)
-@WebFluxTest
+@WebFluxTest({IdServiceHomeController.class})
 public class IdServiceHomeControllerTest {
-  @MockBean ResourceIdentityDetailRepository resources;
 
   @Autowired private WebTestClient client;
 

--- a/ids/src/test/java/gov/va/api/health/ids/service/controller/IdServiceV1ApiControllerTest.java
+++ b/ids/src/test/java/gov/va/api/health/ids/service/controller/IdServiceV1ApiControllerTest.java
@@ -1,16 +1,24 @@
 package gov.va.api.health.ids.service.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import gov.va.api.health.ids.api.Registration;
 import gov.va.api.health.ids.api.ResourceIdentity;
+import gov.va.api.health.ids.service.controller.IdServiceV1ApiController.UuidGenerator;
 import gov.va.api.health.ids.service.controller.impl.ResourceIdentityDetail;
 import gov.va.api.health.ids.service.controller.impl.ResourceIdentityDetailRepository;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import lombok.Value;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,35 +28,75 @@ public class IdServiceV1ApiControllerTest {
 
   @Mock ResourceIdentityDetailRepository repo;
   @Mock ServerWebExchange exchange;
+  @Mock UuidGenerator uuidGenerator;
 
   IdServiceV1ApiController controller;
 
   @Before
   public void _init() {
     MockitoAnnotations.initMocks(this);
-    controller = new IdServiceV1ApiController(repo);
+    controller = new IdServiceV1ApiController(repo, uuidGenerator);
   }
 
   private ResourceIdentity resourceIdentity(int i) {
     return ResourceIdentity.builder().identifier("i" + i).resource("r" + i).system("s" + i).build();
   }
 
-  private ResourceIdentityDetail detail(String uuid, int i) {
+  private Registration registration(String uuid, ResourceIdentity resourceIdentity) {
+    return Registration.builder().uuid(uuid).resourceIdentity(resourceIdentity).build();
+  }
+
+  /**
+   * What a detail will look like if it already exists in the database. The auto-incremented primary
+   * key field 'pk' will be set.
+   */
+  private ResourceIdentityDetail existingDetail(String uuid, int i) {
     return ResourceIdentityDetail.builder()
-        .id(i)
+        .pk(i)
         .identifier("i" + i)
         .resource("r" + i)
         .system("s" + i)
-        .stationIdentifier("st" + i)
+        .uuid(uuid)
+        .build();
+  }
+
+  /**
+   * What a detail will look like if it does not exist in the database. The auto-incremented primary
+   * key field 'pk' will be 0.
+   */
+  private ResourceIdentityDetail newDetail(String uuid, int i) {
+    return ResourceIdentityDetail.builder()
+        .pk(0)
+        .identifier("i" + i)
+        .resource("r" + i)
+        .system("s" + i)
         .uuid(uuid)
         .build();
   }
 
   @Test
-  public void lookupReturnsIdentitiesWhenFound() {
+  public void registrationReturn201AndRegistrationsForUnregisteredId() {
+    ResourceIdentity id1 = resourceIdentity(1);
+    ResourceIdentity id2 = resourceIdentity(2);
+    when(repo.findByUuid(Mockito.anyString())).thenReturn(Collections.emptyList());
+    when(uuidGenerator.apply(id1)).thenReturn("1");
+    when(uuidGenerator.apply(id2)).thenReturn("2");
 
+    ArgumentCaptor<Iterable> saveArgs = ArgumentCaptor.forClass(Iterable.class);
+
+    ResponseEntity<List<Registration>> actual = controller.register(Arrays.asList(id1, id2));
+
+    assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(actual.getBody())
+        .containsExactlyInAnyOrder(registration("1", id1), registration("2", id2));
+    verify(repo).saveAll(saveArgs.capture());
+    assertThat(saveArgs.getValue()).containsExactlyInAnyOrder(newDetail("1", 1), newDetail("2", 2));
+  }
+
+  @Test
+  public void lookupReturns200AndIdentitiesWhenFound() {
     List<ResourceIdentityDetail> searchResults =
-        Arrays.asList(detail("x", 3), detail("x", 2), detail("x", 1));
+        Arrays.asList(existingDetail("x", 3), existingDetail("x", 2), existingDetail("x", 1));
     when(repo.findByUuid("x")).thenReturn(searchResults);
 
     ResponseEntity<List<ResourceIdentity>> actual = controller.lookup("x", exchange);
@@ -56,5 +104,15 @@ public class IdServiceV1ApiControllerTest {
     assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(actual.getBody())
         .containsExactlyInAnyOrder(resourceIdentity(3), resourceIdentity(2), resourceIdentity(1));
+  }
+
+  @Value
+  private static class PredicateAdapter<T> implements ArgumentMatcher<T> {
+    PredicateAdapter<T> predicate;
+
+    @Override
+    public boolean matches(T argument) {
+      return predicate.matches(argument);
+    }
   }
 }

--- a/ids/src/test/java/gov/va/api/health/ids/service/controller/WebExceptionHandlerTest.java
+++ b/ids/src/test/java/gov/va/api/health/ids/service/controller/WebExceptionHandlerTest.java
@@ -1,0 +1,80 @@
+package gov.va.api.health.ids.service.controller;
+
+import static org.mockito.Mockito.when;
+
+import gov.va.api.health.ids.api.IdentityService.LookupFailed;
+import gov.va.api.health.ids.api.IdentityService.RegistrationFailed;
+import gov.va.api.health.ids.api.IdentityService.UnknownIdentity;
+import gov.va.api.health.ids.service.controller.IdServiceV1ApiController.UuidGenerator;
+import gov.va.api.health.ids.service.controller.impl.ResourceIdentityDetailRepository;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import javax.validation.ConstraintViolationException;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.reactive.server.WebTestClient.BodySpec;
+
+@RunWith(Parameterized.class)
+@WebFluxTest
+public class WebExceptionHandlerTest {
+
+  @ClassRule public static final SpringClassRule spring = new SpringClassRule();
+  @Rule public final SpringMethodRule springMethod = new SpringMethodRule();
+
+  @Parameter(0)
+  public HttpStatus status;
+
+  @Parameter(1)
+  public Exception exception;
+
+  @MockBean ResourceIdentityDetailRepository resources;
+  @MockBean UuidGenerator uuidGenerator;
+  @Autowired private WebTestClient client;
+
+  @Parameterized.Parameters(name = "{index}:{0} - {1}")
+  public static List<Object[]> parameters() {
+    return Arrays.asList(
+        test(HttpStatus.NOT_FOUND, new UnknownIdentity("1")),
+        test(HttpStatus.BAD_REQUEST, new ConstraintViolationException(new HashSet<>())),
+        test(HttpStatus.INTERNAL_SERVER_ERROR, new LookupFailed("1", "")),
+        test(HttpStatus.INTERNAL_SERVER_ERROR, new RegistrationFailed("")),
+        test(HttpStatus.INTERNAL_SERVER_ERROR, new RuntimeException())
+        //
+        );
+  }
+
+  private static Object[] test(HttpStatus status, Exception exception) {
+    return new Object[] {status, exception};
+  }
+
+  @Test
+  public void expectStatus() {
+    when(resources.findByUuid(Mockito.any())).thenThrow(exception);
+    when(uuidGenerator.apply(Mockito.any())).thenReturn("x");
+    BodySpec<ErrorResponse, ?> body =
+        client
+            .get()
+            .uri("/api/v1/ids/123")
+            .exchange()
+            .expectStatus()
+            .isEqualTo(status)
+            .expectBody(ErrorResponse.class);
+    ErrorResponse error = body.returnResult().getResponseBody();
+    error.hashCode();
+    error.toString();
+    error.equals(error);
+  }
+}

--- a/ids/src/test/java/gov/va/api/health/ids/service/controller/impl/ResourceIdentityDetailTest.java
+++ b/ids/src/test/java/gov/va/api/health/ids/service/controller/impl/ResourceIdentityDetailTest.java
@@ -13,7 +13,7 @@ public class ResourceIdentityDetailTest {
 
     // has no arg constructor
     ResourceIdentityDetail detail = new ResourceIdentityDetail();
-    detail.id(1);
+    detail.pk(1);
     detail.identifier("i1");
     detail.resource("r1");
     detail.system("s1");
@@ -21,8 +21,8 @@ public class ResourceIdentityDetailTest {
     detail.uuid("youyuoueyedee");
 
     assertThat(detail.hashCode()).isEqualTo(Objects.hash(1));
-    assertThat(detail).isEqualTo(ResourceIdentityDetail.builder().id(1).build());
-    assertThat(detail).isNotEqualTo(ResourceIdentityDetail.builder().id(2).build());
+    assertThat(detail).isEqualTo(ResourceIdentityDetail.builder().pk(1).build());
+    assertThat(detail).isNotEqualTo(ResourceIdentityDetail.builder().pk(2).build());
     assertThat(detail).isNotEqualTo(null);
     assertThat(detail).isEqualTo(detail);
     detail.toString();

--- a/ids/src/test/java/gov/va/api/health/ids/service/controller/impl/Type5UuidGeneratorTest.java
+++ b/ids/src/test/java/gov/va/api/health/ids/service/controller/impl/Type5UuidGeneratorTest.java
@@ -1,0 +1,30 @@
+package gov.va.api.health.ids.service.controller.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gov.va.api.health.ids.api.ResourceIdentity;
+import java.util.UUID;
+import lombok.Getter;
+import org.junit.Test;
+
+public class Type5UuidGeneratorTest {
+
+  @Getter
+  private final Type5UuidGenerator generator = new Type5UuidGenerator(UUID.randomUUID().toString());
+
+  @Test(expected = NullPointerException.class)
+  public void nullValueIsRejected() {
+    generator().apply(null);
+  }
+
+  @Test
+  public void generationIsDeterministic() {
+    ResourceIdentity id =
+        ResourceIdentity.builder().system("s1").resource("r1").identifier("i1").build();
+    String uuid1 = generator().apply(id);
+    String uuid2 = generator().apply(id);
+    assertThat(uuid1).isNotBlank().isEqualTo(uuid2);
+    // Throws exception if the uuid cannot be parsed as a proper UUID.
+    UUID.fromString(uuid1);
+  }
+}


### PR DESCRIPTION

Registration support for identity service part 1
    - ids/README now describes the behavior of the identity service
    - ids/run-local.sh now builds before running
    - new ids/dmeo.sh script to show off a little functionality
    - Added validation annotations to IDs model
    - basic registration support for ids, but no error handling
    - validation errors returned as 400.