### PR TITLE
Task/api 111 use jenkins provided keystore credentials

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,3 +1,3 @@
-spring\.datasource\.url=(unset|\$[A-Z_]+)
-spring\.datasource\.username=(unset|\$[A-Z_]+)
-[a-z.-]+(\.|-)password=(unset|\$[A-Z_]+)
+spring\.datasource\.url=(unset|\${?[a-zA-Z_]+}?)
+spring\.datasource\.username=(unset|\${?[a-zA-Z_]+}?)
+[a-z.-]+(\.|-)password=(unset|\${?[a-zA-Z_]+}?)

--- a/sentinel/pom.xml
+++ b/sentinel/pom.xml
@@ -108,7 +108,7 @@
             <configuration>
               <name>ids</name>
               <waitForInterrupt>false</waitForInterrupt>
-              <processLogFile>${project.build.directory}/ids.log</processLogFile>
+             <!-- <processLogFile>${project.build.directory}/ids.log</processLogFile> -->
               <healthcheckUrl>https://localhost:8089/actuator/health</healthcheckUrl>
               <skip>${sentinel.skipLaunch}</skip>
               <arguments>

--- a/sentinel/pom.xml
+++ b/sentinel/pom.xml
@@ -108,7 +108,7 @@
             <configuration>
               <name>ids</name>
               <waitForInterrupt>false</waitForInterrupt>
-             <!-- <processLogFile>${project.build.directory}/ids.log</processLogFile> -->
+              <!-- <processLogFile>${project.build.directory}/ids.log</processLogFile> -->
               <healthcheckUrl>https://localhost:8089/actuator/health</healthcheckUrl>
               <skip>${sentinel.skipLaunch}</skip>
               <arguments>
@@ -213,6 +213,47 @@
       <properties>
         <sentinel.skipLaunch>true</sentinel.skipLaunch>
       </properties>
+    </profile>
+    <!--
+      On Jenkins, the certificate password is provided by Jenkins credentials system and
+      made available as the environment variable 'HEALTH_API_CERTIFICATE_PASSWORD'. This
+      profile generates the 'config/secrets.properties' needed to launch the application.
+    -->
+    <profile>
+      <id>jenkins-config</id>
+      <activation>
+        <property>
+          <name>env.HEALTH_API_CERTIFICATE_PASSWORD</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>create-secrets-config</id>
+                <phase>generate-test-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.basedir}/config</outputDirectory>
+                  <delimiters>
+                    <delimiter>${*}</delimiter>
+                  </delimiters>
+                  <resources>
+                    <resource>
+                      <directory>src/test/config</directory>
+                      <filtering>true</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>docker</id>

--- a/sentinel/src/test/config/secrets.properties
+++ b/sentinel/src/test/config/secrets.properties
@@ -1,0 +1,4 @@
+server.ssl.key-store-password=${env.HEALTH_API_CERTIFICATE_PASSWORD}
+ssl.key-store-password=${env.HEALTH_API_CERTIFICATE_PASSWORD}
+ssl.client-key-password=${env.HEALTH_API_CERTIFICATE_PASSWORD}
+ssl.trust-store-password=${env.HEALTH_API_CERTIFICATE_PASSWORD}


### PR DESCRIPTION
This PR updates `sentinel` so that it can run in Jenkins environment. Jenkins provides the keystore password as a credential object, which is ultimate passed to Maven as an environment variable. The `sentinel` pom has been updated to trigger a profile based on the presence of the `HEALTH_API_CERTIFICATE_PASSWORD` environment variable. When triggered it will create `sentinel/config/secrets.properties` based on a resources template that is filtered by Maven.


This can be tested by ...
```
cd sentinel
mv config/secret.properties . # save your copy
export HEALTH_API_CERTIFICATE_PASSWORD=12345
mvn generate-test-resources
cat config/secrets.properties
```