### PR TITLE
Task/api 176 key alias support

### DIFF
--- a/argonaut/pom.xml
+++ b/argonaut/pom.xml
@@ -23,6 +23,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>gov.va.dvp</groupId>
       <artifactId>cdw-schemas</artifactId>
       <version>${cdw-schemas.version}</version>

--- a/argonaut/pom.xml
+++ b/argonaut/pom.xml
@@ -23,11 +23,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.projectreactor</groupId>
-      <artifactId>reactor-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>gov.va.dvp</groupId>
       <artifactId>cdw-schemas</artifactId>
       <version>${cdw-schemas.version}</version>

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/ArgonautHomeController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/ArgonautHomeController.java
@@ -33,8 +33,9 @@ public class ArgonautHomeController {
    * redirect.
    */
   @GetMapping(
-      value = {"/", "/openapi.json"},
-      produces = "application/json")
+    value = {"/", "/openapi.json"},
+    produces = "application/json"
+  )
   @ResponseBody
   public Object openapiJson() throws IOException {
     return ArgonautHomeController.MAPPER.readValue(openapiContent(), Object.class);

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/ArgonautHomeController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/ArgonautHomeController.java
@@ -1,12 +1,8 @@
 package gov.va.api.health.argonaut.service.controller;
 
-import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
-import static org.springframework.web.reactive.function.server.RouterFunctions.route;
-
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.nio.charset.Charset;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,8 +11,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.reactive.function.server.RouterFunction;
-import org.springframework.web.reactive.function.server.ServerResponse;
 
 @Controller
 public class ArgonautHomeController {
@@ -25,12 +19,6 @@ public class ArgonautHomeController {
 
   @Value("classpath:/openapi.yaml")
   private Resource openapi;
-
-  @Bean
-  RouterFunction<ServerResponse> index() {
-    return route(
-        GET("/"), req -> ServerResponse.temporaryRedirect(URI.create("/openapi.json")).build());
-  }
 
   /** The OpenAPI specific content in yaml form. */
   @Bean
@@ -44,7 +32,9 @@ public class ArgonautHomeController {
    * Provide access to the OpenAPI as JSON via RESTful interface. This is also used as the /
    * redirect.
    */
-  @GetMapping(value = "/openapi.json", produces = "application/json")
+  @GetMapping(
+      value = {"/", "/openapi.json"},
+      produces = "application/json")
   @ResponseBody
   public Object openapiJson() throws IOException {
     return ArgonautHomeController.MAPPER.readValue(openapiContent(), Object.class);

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/WebExceptionHandler.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/WebExceptionHandler.java
@@ -10,6 +10,7 @@ import gov.va.api.health.argonaut.service.mranderson.client.MrAndersonClient.Not
 import java.time.Instant;
 import java.util.Collections;
 import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -17,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.server.ServerWebExchange;
 
 /**
  * Exceptions that escape the rest controllers will be processed by this handler. It will convert
@@ -30,30 +30,30 @@ public class WebExceptionHandler {
 
   @ExceptionHandler({BadRequest.class, javax.validation.ConstraintViolationException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  public OperationOutcome handleBadRequest(Exception e, ServerWebExchange exchange) {
-    return responseFor("structure", e, exchange);
+  public OperationOutcome handleBadRequest(Exception e, HttpServletRequest request) {
+    return responseFor("structure", e, request);
   }
 
   @ExceptionHandler({NotFound.class, HttpClientErrorException.NotFound.class})
   @ResponseStatus(HttpStatus.NOT_FOUND)
-  public OperationOutcome handleNotFound(Exception e, ServerWebExchange exchange) {
-    return responseFor("not-found", e, exchange);
+  public OperationOutcome handleNotFound(Exception e, HttpServletRequest request) {
+    return responseFor("not-found", e, request);
   }
 
   @ExceptionHandler({Exception.class})
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-  public OperationOutcome handleSnafu(Exception e, ServerWebExchange exchange) {
-    return responseFor("exception", e, exchange);
+  public OperationOutcome handleSnafu(Exception e, HttpServletRequest request) {
+    return responseFor("exception", e, request);
   }
 
-  private OperationOutcome responseFor(String code, Exception e, ServerWebExchange exchange) {
+  private OperationOutcome responseFor(String code, Exception e, HttpServletRequest request) {
     OperationOutcome response =
         OperationOutcome.builder()
             .id(UUID.randomUUID().toString())
             .text(
                 Narrative.builder()
                     .status(NarrativeStatus.additional)
-                    .div("<div>Failure: " + exchange.getRequest().getPath().toString() + "</div>")
+                    .div("<div>Failure: " + request.getRequestURI() + "</div>")
                     .build())
             .issue(
                 Collections.singletonList(

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/patient/PatientController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/patient/PatientController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ServerWebExchange;
 
 /**
  * Request Mappings for the Argonaut Patient Profile, see
@@ -37,7 +36,7 @@ public class PatientController {
 
   /** Read by id. */
   @GetMapping(value = {"/{publicId}"})
-  public Patient read(@PathVariable("publicId") String publicId, ServerWebExchange exchange) {
+  public Patient read(@PathVariable("publicId") String publicId) {
 
     Query<Patient103Root> query =
         Query.forType(Patient103Root.class)

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/ArgonautHomeControllerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/ArgonautHomeControllerTest.java
@@ -1,66 +1,51 @@
 package gov.va.api.health.argonaut.service.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.nio.charset.StandardCharsets;
 import lombok.SneakyThrows;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.StreamUtils;
 
 @RunWith(SpringRunner.class)
-@WebFluxTest({ArgonautHomeController.class})
+@WebMvcTest(controllers = {ArgonautHomeController.class})
 public class ArgonautHomeControllerTest {
 
-  @Autowired private WebTestClient client;
+  @Autowired private MockMvc mvc;
 
   @Test
   @SneakyThrows
   public void openapiJson() {
-    client
-        .get()
-        .uri("/openapi.json")
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody()
-        .jsonPath("$.openapi", "3.0.1");
+    mvc.perform(get("/openapi.json"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.openapi", equalTo("3.0.1")));
   }
 
   @Test
   @SneakyThrows
   public void openapiYaml() {
-    byte[] responseBody =
-        client
-            .get()
-            .uri("/openapi.yaml")
-            .exchange()
-            .expectStatus()
-            .isOk()
-            .expectBody()
-            .returnResult()
-            .getResponseBody();
-
-    assertThat(new String(responseBody, StandardCharsets.UTF_8))
-        .isEqualTo(
-            StreamUtils.copyToString(
-                getClass().getResourceAsStream("/openapi.yaml"), StandardCharsets.UTF_8));
+    String expected =
+        StreamUtils.copyToString(
+            getClass().getResourceAsStream("/openapi.yaml"), StandardCharsets.UTF_8);
+    mvc.perform(get("/openapi.yaml"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(equalTo(expected)));
   }
 
   @Test
   @SneakyThrows
   public void openapiYamlFromIndex() {
-    client
-        .get()
-        .uri("/")
-        .exchange()
-        .expectStatus()
-        .isTemporaryRedirect()
-        .expectHeader()
-        .valueMatches("Location", ".*/openapi.json");
+    mvc.perform(get("/"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.openapi", equalTo("3.0.1")));
   }
 }

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/patient/PatientControllerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/patient/PatientControllerTest.java
@@ -18,15 +18,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.springframework.web.server.ServerWebExchange;
 
 public class PatientControllerTest {
 
   @Mock MrAndersonClient client;
 
   @Mock PatientController.Transformer tx;
-
-  @Mock ServerWebExchange exchange;
 
   PatientController controller;
 
@@ -45,7 +42,7 @@ public class PatientControllerTest {
     Patient patient = Patient.builder().build();
     when(client.search(Mockito.any())).thenReturn(root);
     when(tx.apply(xmlPatient)).thenReturn(patient);
-    Patient actual = controller.read("hello", exchange);
+    Patient actual = controller.read("hello");
     assertThat(actual).isSameAs(patient);
     ArgumentCaptor<Query<Patient103Root>> captor = ArgumentCaptor.forClass(Query.class);
     verify(client).search(captor.capture());

--- a/ids/src/main/java/gov/va/api/health/ids/service/controller/IdServiceHomeController.java
+++ b/ids/src/main/java/gov/va/api/health/ids/service/controller/IdServiceHomeController.java
@@ -1,12 +1,8 @@
 package gov.va.api.health.ids.service.controller;
 
-import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
-import static org.springframework.web.reactive.function.server.RouterFunctions.route;
-
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.nio.charset.Charset;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,8 +11,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.reactive.function.server.RouterFunction;
-import org.springframework.web.reactive.function.server.ServerResponse;
 
 @Controller
 public class IdServiceHomeController {
@@ -34,26 +28,23 @@ public class IdServiceHomeController {
     }
   }
 
-  /** Provide access to the OpenAPI yaml via RESTful interface. */
-  @GetMapping(value = "/openapi.yaml", produces = "application/vnd.oai.openapi")
-  @ResponseBody
-  public String openapiYaml() throws IOException {
-    return openapiContent();
-  }
-
   /**
    * Provide access to the OpenAPI as JSON via RESTful interface. This is also used as the /
    * redirect.
    */
-  @GetMapping(value = "/openapi.json", produces = "application/json")
+  @GetMapping(
+    value = {"/", "/openapi.json"},
+    produces = "application/json"
+  )
   @ResponseBody
   public Object openapiJson() throws IOException {
     return IdServiceHomeController.MAPPER.readValue(openapiContent(), Object.class);
   }
 
-  @Bean
-  RouterFunction<ServerResponse> index() {
-    return route(
-        GET("/"), req -> ServerResponse.temporaryRedirect(URI.create("/openapi.json")).build());
+  /** Provide access to the OpenAPI yaml via RESTful interface. */
+  @GetMapping(value = "/openapi.yaml", produces = "application/vnd.oai.openapi")
+  @ResponseBody
+  public String openapiYaml() throws IOException {
+    return openapiContent();
   }
 }

--- a/ids/src/main/java/gov/va/api/health/ids/service/controller/IdServiceV1ApiController.java
+++ b/ids/src/main/java/gov/va/api/health/ids/service/controller/IdServiceV1ApiController.java
@@ -22,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ServerWebExchange;
 
 @RestController
 @Validated
@@ -40,14 +39,12 @@ public class IdServiceV1ApiController {
 
   /** Implementation of GET /v1/ids/{publicId}. See api-v1.yaml. */
   @RequestMapping(
-    value = {"/v1/ids/{publicId}", "/resourceIdentity/{publicId}"},
-    produces = {"application/json"},
-    method = RequestMethod.GET
-  )
+      value = {"/v1/ids/{publicId}", "/resourceIdentity/{publicId}"},
+      produces = {"application/json"},
+      method = RequestMethod.GET)
   @SneakyThrows
   public ResponseEntity<List<ResourceIdentity>> lookup(
-      @Valid @PathVariable("publicId") @Pattern(regexp = "[-A-Za-z0-9]+") String publicId,
-      ServerWebExchange exchange) {
+      @Valid @PathVariable("publicId") @Pattern(regexp = "[-A-Za-z0-9]+") String publicId) {
 
     List<ResourceIdentity> identities =
         repository
@@ -66,11 +63,10 @@ public class IdServiceV1ApiController {
 
   /** Implementation of POST /v1/ids. See api-v1.yaml. */
   @RequestMapping(
-    value = {"/v1/ids", "/resourceIdentity"},
-    produces = {"application/json"},
-    consumes = {"application/json"},
-    method = RequestMethod.POST
-  )
+      value = {"/v1/ids", "/resourceIdentity"},
+      produces = {"application/json"},
+      consumes = {"application/json"},
+      method = RequestMethod.POST)
   public ResponseEntity<List<Registration>> register(
       @Valid @RequestBody List<ResourceIdentity> identities) {
 
@@ -83,6 +79,7 @@ public class IdServiceV1ApiController {
             .filter(this::isNotRegistered)
             .map(this::toDatabaseEntry)
             .collect(Collectors.toList());
+    newRegistrations.forEach(x -> log.info("{}", x));
     log.info("Register {} entries ({} are new)", identities.size(), newRegistrations.size());
     repository.saveAll(newRegistrations);
 

--- a/ids/src/main/java/gov/va/api/health/ids/service/controller/IdServiceV1ApiController.java
+++ b/ids/src/main/java/gov/va/api/health/ids/service/controller/IdServiceV1ApiController.java
@@ -39,9 +39,10 @@ public class IdServiceV1ApiController {
 
   /** Implementation of GET /v1/ids/{publicId}. See api-v1.yaml. */
   @RequestMapping(
-      value = {"/v1/ids/{publicId}", "/resourceIdentity/{publicId}"},
-      produces = {"application/json"},
-      method = RequestMethod.GET)
+    value = {"/v1/ids/{publicId}", "/resourceIdentity/{publicId}"},
+    produces = {"application/json"},
+    method = RequestMethod.GET
+  )
   @SneakyThrows
   public ResponseEntity<List<ResourceIdentity>> lookup(
       @Valid @PathVariable("publicId") @Pattern(regexp = "[-A-Za-z0-9]+") String publicId) {
@@ -63,10 +64,11 @@ public class IdServiceV1ApiController {
 
   /** Implementation of POST /v1/ids. See api-v1.yaml. */
   @RequestMapping(
-      value = {"/v1/ids", "/resourceIdentity"},
-      produces = {"application/json"},
-      consumes = {"application/json"},
-      method = RequestMethod.POST)
+    value = {"/v1/ids", "/resourceIdentity"},
+    produces = {"application/json"},
+    consumes = {"application/json"},
+    method = RequestMethod.POST
+  )
   public ResponseEntity<List<Registration>> register(
       @Valid @RequestBody List<ResourceIdentity> identities) {
 

--- a/ids/src/main/java/gov/va/api/health/ids/service/controller/impl/ResourceIdentityDetail.java
+++ b/ids/src/main/java/gov/va/api/health/ids/service/controller/impl/ResourceIdentityDetail.java
@@ -8,8 +8,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -49,29 +49,38 @@ public class ResourceIdentityDetail {
   @Column(name = "id")
   int pk;
 
-  @Column(name = "identifier")
-  @Max(45)
+  @Column(name = "identifier", length = 45)
+  @Size(max = 45)
   @NotBlank
   String identifier;
 
-  @Column(name = "station_identifier")
-  @Max(45)
+  @Column(name = "station_identifier", length = 45)
+  @Size(max = 45)
   String stationIdentifier;
 
-  @Column(name = "uuid")
-  @Max(45)
+  @Column(name = "uuid", length = 45)
+  @Size(max = 45)
   @NotBlank
   String uuid;
 
-  @Column(name = "system")
-  @Max(45)
+  @Column(name = "system", length = 45)
+  @Size(max = 45)
   @NotBlank
   String system;
 
-  @Column(name = "resource")
-  @Max(45)
+  @Column(name = "resource", length = 45)
+  @Size(max = 45)
   @NotBlank
   String resource;
+
+  /** Convert this database entity into a more friendly, non-JPA form. */
+  public ResourceIdentity asResourceIdentity() {
+    return ResourceIdentity.builder()
+        .identifier(identifier())
+        .system(system())
+        .resource(resource())
+        .build();
+  }
 
   @Override
   public boolean equals(Object o) {
@@ -88,14 +97,5 @@ public class ResourceIdentityDetail {
   @Override
   public int hashCode() {
     return Objects.hash(pk);
-  }
-
-  /** Convert this database entity into a more friendly, non-JPA form. */
-  public ResourceIdentity asResourceIdentity() {
-    return ResourceIdentity.builder()
-        .identifier(identifier())
-        .system(system())
-        .resource(resource())
-        .build();
   }
 }

--- a/ids/src/test/java/gov/va/api/health/ids/service/controller/ErrorResponseTest.java
+++ b/ids/src/test/java/gov/va/api/health/ids/service/controller/ErrorResponseTest.java
@@ -8,6 +8,11 @@ import lombok.SneakyThrows;
 import org.junit.Test;
 
 public class ErrorResponseTest {
+  @Test
+  public void errorResponse() {
+    roundTrip(ErrorResponse.of(new RuntimeException("fugazi")));
+  }
+
   @SneakyThrows
   private <T> T roundTrip(T object) {
     ObjectMapper mapper = new JacksonConfig().objectMapper();
@@ -15,10 +20,5 @@ public class ErrorResponseTest {
     Object evilTwin = mapper.readValue(json, object.getClass());
     assertThat(evilTwin).isEqualTo(object);
     return object;
-  }
-
-  @Test
-  public void errorResponse() {
-    roundTrip(ErrorResponse.of(new RuntimeException("fugazi")));
   }
 }

--- a/ids/src/test/java/gov/va/api/health/ids/service/controller/IdServiceHomeControllerTest.java
+++ b/ids/src/test/java/gov/va/api/health/ids/service/controller/IdServiceHomeControllerTest.java
@@ -1,6 +1,10 @@
 package gov.va.api.health.ids.service.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.nio.charset.StandardCharsets;
 import lombok.SneakyThrows;
@@ -9,58 +13,39 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.StreamUtils;
 
 @RunWith(SpringRunner.class)
-@WebMvcTest({IdServiceHomeController.class})
+@WebMvcTest(controllers = {IdServiceHomeController.class})
 public class IdServiceHomeControllerTest {
 
-  @Autowired private WebTestClient client;
+  @Autowired private MockMvc mvc;
 
   @Test
   @SneakyThrows
   public void openapiJson() {
-    client
-        .get()
-        .uri("/openapi.json")
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody()
-        .jsonPath("$.openapi", "3.0.1");
+    mvc.perform(get("/openapi.json"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.openapi", equalTo("3.0.1")));
   }
 
   @Test
   @SneakyThrows
   public void openapiYaml() {
-    byte[] responseBody =
-        client
-            .get()
-            .uri("/openapi.yaml")
-            .exchange()
-            .expectStatus()
-            .isOk()
-            .expectBody()
-            .returnResult()
-            .getResponseBody();
-
-    assertThat(new String(responseBody, StandardCharsets.UTF_8))
-        .isEqualTo(
-            StreamUtils.copyToString(
-                getClass().getResourceAsStream("/api-v1.yaml"), StandardCharsets.UTF_8));
+    String expected =
+        StreamUtils.copyToString(
+            getClass().getResourceAsStream("/api-v1.yaml"), StandardCharsets.UTF_8);
+    mvc.perform(get("/openapi.yaml"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(equalTo(expected)));
   }
 
   @Test
   @SneakyThrows
   public void openapiYamlFromIndex() {
-    client
-        .get()
-        .uri("/")
-        .exchange()
-        .expectStatus()
-        .isTemporaryRedirect()
-        .expectHeader()
-        .valueMatches("Location", ".*/openapi.json");
+    mvc.perform(get("/"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.openapi", equalTo("3.0.1")));
   }
 }

--- a/ids/src/test/java/gov/va/api/health/ids/service/controller/IdServiceHomeControllerTest.java
+++ b/ids/src/test/java/gov/va/api/health/ids/service/controller/IdServiceHomeControllerTest.java
@@ -7,16 +7,29 @@ import lombok.SneakyThrows;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.util.StreamUtils;
 
 @RunWith(SpringRunner.class)
-@WebFluxTest({IdServiceHomeController.class})
+@WebMvcTest({IdServiceHomeController.class})
 public class IdServiceHomeControllerTest {
 
   @Autowired private WebTestClient client;
+
+  @Test
+  @SneakyThrows
+  public void openapiJson() {
+    client
+        .get()
+        .uri("/openapi.json")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.openapi", "3.0.1");
+  }
 
   @Test
   @SneakyThrows
@@ -36,19 +49,6 @@ public class IdServiceHomeControllerTest {
         .isEqualTo(
             StreamUtils.copyToString(
                 getClass().getResourceAsStream("/api-v1.yaml"), StandardCharsets.UTF_8));
-  }
-
-  @Test
-  @SneakyThrows
-  public void openapiJson() {
-    client
-        .get()
-        .uri("/openapi.json")
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody()
-        .jsonPath("$.openapi", "3.0.1");
   }
 
   @Test

--- a/ids/src/test/java/gov/va/api/health/ids/service/controller/IdServiceV1ApiControllerTest.java
+++ b/ids/src/test/java/gov/va/api/health/ids/service/controller/IdServiceV1ApiControllerTest.java
@@ -26,13 +26,11 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.server.ServerWebExchange;
 
 public class IdServiceV1ApiControllerTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
   @Mock ResourceIdentityDetailRepository repo;
-  @Mock ServerWebExchange exchange;
   @Mock UuidGenerator uuidGenerator;
   IdServiceV1ApiController controller;
 
@@ -40,14 +38,6 @@ public class IdServiceV1ApiControllerTest {
   public void _init() {
     MockitoAnnotations.initMocks(this);
     controller = new IdServiceV1ApiController(repo, uuidGenerator);
-  }
-
-  private ResourceIdentity resourceIdentity(int i) {
-    return ResourceIdentity.builder().identifier("i" + i).resource("r" + i).system("s" + i).build();
-  }
-
-  private Registration registration(String uuid, ResourceIdentity resourceIdentity) {
-    return Registration.builder().uuid(uuid).resourceIdentity(resourceIdentity).build();
   }
 
   /**
@@ -64,6 +54,28 @@ public class IdServiceV1ApiControllerTest {
         .build();
   }
 
+  @Test
+  public void lookupReturns200AndIdentitiesWhenFound() {
+    List<ResourceIdentityDetail> searchResults =
+        Arrays.asList(existingDetail("x", 3), existingDetail("x", 2), existingDetail("x", 1));
+    when(repo.findByUuid("x")).thenReturn(searchResults);
+
+    ResponseEntity<List<ResourceIdentity>> actual = controller.lookup("x");
+
+    assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(actual.getBody())
+        .containsExactlyInAnyOrder(resourceIdentity(3), resourceIdentity(2), resourceIdentity(1));
+  }
+
+  @Test
+  public void lookupThrowsUnknownIdentityExceptionWhenNoIdentitiesAreFound() {
+    thrown.expect(UnknownIdentity.class);
+    List<ResourceIdentityDetail> searchResults = new ArrayList<>();
+    when(repo.findByUuid("x")).thenReturn(searchResults);
+
+    controller.lookup("x");
+  }
+
   /**
    * What a detail will look like if it does not exist in the database. The auto-incremented primary
    * key field 'pk' will be 0.
@@ -76,6 +88,10 @@ public class IdServiceV1ApiControllerTest {
         .system("s" + i)
         .uuid(uuid)
         .build();
+  }
+
+  private Registration registration(String uuid, ResourceIdentity resourceIdentity) {
+    return Registration.builder().uuid(uuid).resourceIdentity(resourceIdentity).build();
   }
 
   @Test
@@ -97,26 +113,8 @@ public class IdServiceV1ApiControllerTest {
     assertThat(saveArgs.getValue()).containsExactlyInAnyOrder(newDetail("1", 1), newDetail("2", 2));
   }
 
-  @Test
-  public void lookupReturns200AndIdentitiesWhenFound() {
-    List<ResourceIdentityDetail> searchResults =
-        Arrays.asList(existingDetail("x", 3), existingDetail("x", 2), existingDetail("x", 1));
-    when(repo.findByUuid("x")).thenReturn(searchResults);
-
-    ResponseEntity<List<ResourceIdentity>> actual = controller.lookup("x", exchange);
-
-    assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(actual.getBody())
-        .containsExactlyInAnyOrder(resourceIdentity(3), resourceIdentity(2), resourceIdentity(1));
-  }
-
-  @Test
-  public void lookupThrowsUnknownIdentityExceptionWhenNoIdentitiesAreFound() {
-    thrown.expect(UnknownIdentity.class);
-    List<ResourceIdentityDetail> searchResults = new ArrayList<>();
-    when(repo.findByUuid("x")).thenReturn(searchResults);
-
-    controller.lookup("x", exchange);
+  private ResourceIdentity resourceIdentity(int i) {
+    return ResourceIdentity.builder().identifier("i" + i).resource("r" + i).system("s" + i).build();
   }
 
   @Value

--- a/ids/src/test/java/gov/va/api/health/ids/service/controller/WebExceptionHandlerTest.java
+++ b/ids/src/test/java/gov/va/api/health/ids/service/controller/WebExceptionHandlerTest.java
@@ -1,38 +1,42 @@
 package gov.va.api.health.ids.service.controller;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import gov.va.api.health.autoconfig.configuration.JacksonConfig;
 import gov.va.api.health.ids.api.IdentityService.LookupFailed;
 import gov.va.api.health.ids.api.IdentityService.RegistrationFailed;
 import gov.va.api.health.ids.api.IdentityService.UnknownIdentity;
 import gov.va.api.health.ids.service.controller.IdServiceV1ApiController.UuidGenerator;
 import gov.va.api.health.ids.service.controller.impl.ResourceIdentityDetailRepository;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import javax.validation.ConstraintViolationException;
-import org.junit.ClassRule;
-import org.junit.Rule;
+import lombok.SneakyThrows;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
+import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
-import org.springframework.test.web.reactive.server.WebTestClient;
-import org.springframework.test.web.reactive.server.WebTestClient.BodySpec;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver;
+import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
+import org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod;
 
 @RunWith(Parameterized.class)
-@WebFluxTest
 public class WebExceptionHandlerTest {
-
-  @ClassRule public static final SpringClassRule spring = new SpringClassRule();
-  @Rule public final SpringMethodRule springMethod = new SpringMethodRule();
 
   @Parameter(0)
   public HttpStatus status;
@@ -40,9 +44,12 @@ public class WebExceptionHandlerTest {
   @Parameter(1)
   public Exception exception;
 
-  @MockBean ResourceIdentityDetailRepository resources;
-  @MockBean UuidGenerator uuidGenerator;
-  @Autowired private WebTestClient client;
+  @Mock ResourceIdentityDetailRepository resources;
+
+  @Mock UuidGenerator uuidGenerator;
+
+  IdServiceV1ApiController controller;
+  WebExceptionHandler exceptionHandler;
 
   @Parameterized.Parameters(name = "{index}:{0} - {1}")
   public static List<Object[]> parameters() {
@@ -60,21 +67,44 @@ public class WebExceptionHandlerTest {
     return new Object[] {status, exception};
   }
 
+  @Before
+  public void _init() {
+    MockitoAnnotations.initMocks(this);
+    controller = new IdServiceV1ApiController(resources, uuidGenerator);
+    exceptionHandler = new WebExceptionHandler();
+  }
+
+  private ExceptionHandlerExceptionResolver createExceptionResolver() {
+    ExceptionHandlerExceptionResolver exceptionResolver =
+        new ExceptionHandlerExceptionResolver() {
+          @Override
+          protected ServletInvocableHandlerMethod getExceptionHandlerMethod(
+              HandlerMethod handlerMethod, Exception exception) {
+            Method method =
+                new ExceptionHandlerMethodResolver(WebExceptionHandler.class)
+                    .resolveMethod(exception);
+            return new ServletInvocableHandlerMethod(exceptionHandler, method);
+          }
+        };
+    exceptionResolver
+        .getMessageConverters()
+        .add(new MappingJackson2HttpMessageConverter(JacksonConfig.createMapper()));
+    exceptionResolver.afterPropertiesSet();
+    return exceptionResolver;
+  }
+
   @Test
+  @SneakyThrows
   public void expectStatus() {
     when(resources.findByUuid(Mockito.any())).thenThrow(exception);
     when(uuidGenerator.apply(Mockito.any())).thenReturn("x");
-    BodySpec<ErrorResponse, ?> body =
-        client
-            .get()
-            .uri("/api/v1/ids/123")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(status)
-            .expectBody(ErrorResponse.class);
-    ErrorResponse error = body.returnResult().getResponseBody();
-    error.hashCode();
-    error.toString();
-    error.equals(error);
+    MockMvc mvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .setHandlerExceptionResolvers(createExceptionResolver())
+            .build();
+
+    mvc.perform(get("/api/v1/ids/123"))
+        .andExpect(status().is(status.value()))
+        .andExpect(jsonPath("type", equalTo(exception.getClass().getSimpleName())));
   }
 }

--- a/mr-anderson/pom.xml
+++ b/mr-anderson/pom.xml
@@ -35,5 +35,10 @@
       <artifactId>ids-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/mr-anderson/pom.xml
+++ b/mr-anderson/pom.xml
@@ -35,10 +35,5 @@
       <artifactId>ids-api</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>io.projectreactor</groupId>
-      <artifactId>reactor-core</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/mr-anderson/src/main/java/gov/va/api/health/mranderson/controller/MrAndersonHomeController.java
+++ b/mr-anderson/src/main/java/gov/va/api/health/mranderson/controller/MrAndersonHomeController.java
@@ -33,8 +33,9 @@ public class MrAndersonHomeController {
    * redirect.
    */
   @GetMapping(
-      value = {"/", "/openapi.json"},
-      produces = "application/json")
+    value = {"/", "/openapi.json"},
+    produces = "application/json"
+  )
   @ResponseBody
   public Object openapiJson() throws IOException {
     return MrAndersonHomeController.yamlMapper.readValue(openapiContent(), Object.class);

--- a/mr-anderson/src/main/java/gov/va/api/health/mranderson/controller/MrAndersonHomeController.java
+++ b/mr-anderson/src/main/java/gov/va/api/health/mranderson/controller/MrAndersonHomeController.java
@@ -1,12 +1,8 @@
 package gov.va.api.health.mranderson.controller;
 
-import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
-import static org.springframework.web.reactive.function.server.RouterFunctions.route;
-
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.nio.charset.Charset;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,8 +11,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.reactive.function.server.RouterFunction;
-import org.springframework.web.reactive.function.server.ServerResponse;
 
 @Controller
 public class MrAndersonHomeController {
@@ -34,26 +28,22 @@ public class MrAndersonHomeController {
     }
   }
 
-  /** Provide access to the OpenAPI yaml via RESTful interface. */
-  @GetMapping(value = "/openapi.yaml", produces = "application/vnd.oai.openapi")
-  @ResponseBody
-  public String openapiYaml() throws IOException {
-    return openapiContent();
-  }
-
   /**
    * Provide access to the OpenAPI as JSON via RESTful interface. This is also used as the /
    * redirect.
    */
-  @GetMapping(value = "/openapi.json", produces = "application/json")
+  @GetMapping(
+      value = {"/", "/openapi.json"},
+      produces = "application/json")
   @ResponseBody
   public Object openapiJson() throws IOException {
     return MrAndersonHomeController.yamlMapper.readValue(openapiContent(), Object.class);
   }
 
-  @Bean
-  RouterFunction<ServerResponse> index() {
-    return route(
-        GET("/"), req -> ServerResponse.temporaryRedirect(URI.create("/openapi.json")).build());
+  /** Provide access to the OpenAPI yaml via RESTful interface. */
+  @GetMapping(value = "/openapi.yaml", produces = "application/vnd.oai.openapi")
+  @ResponseBody
+  public String openapiYaml() throws IOException {
+    return openapiContent();
   }
 }

--- a/mr-anderson/src/main/java/gov/va/api/health/mranderson/controller/MrAndersonV1ApiController.java
+++ b/mr-anderson/src/main/java/gov/va/api/health/mranderson/controller/MrAndersonV1ApiController.java
@@ -29,6 +29,19 @@ public class MrAndersonV1ApiController {
 
   private final Resources resources;
 
+  /** Support profile values in any case. */
+  @InitBinder
+  public void initBinder(WebDataBinder dataBinder) {
+    dataBinder.registerCustomEditor(
+        Profile.class,
+        new PropertyEditorSupport() {
+          @Override
+          public void setAsText(String text) throws IllegalArgumentException {
+            setValue(Profile.fromValue(text));
+          }
+        });
+  }
+
   /**
    * Implementation of /v1/resources/{profile}/{resourceType}/{resourceVersion}. See api-v1.yaml.
    */
@@ -63,18 +76,5 @@ public class MrAndersonV1ApiController {
                 .build());
 
     return ResponseEntity.ok().body(xml);
-  }
-
-  /** Support profile values in any case. */
-  @InitBinder
-  public void initBinder(WebDataBinder dataBinder) {
-    dataBinder.registerCustomEditor(
-        Profile.class,
-        new PropertyEditorSupport() {
-          @Override
-          public void setAsText(String text) throws IllegalArgumentException {
-            setValue(Profile.fromValue(text));
-          }
-        });
   }
 }

--- a/mr-anderson/src/main/java/gov/va/api/health/mranderson/controller/MrAndersonV1ApiController.java
+++ b/mr-anderson/src/main/java/gov/va/api/health/mranderson/controller/MrAndersonV1ApiController.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.InitBinder;
@@ -19,7 +20,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ServerWebExchange;
 
 @RestController
 @Validated
@@ -62,7 +62,7 @@ public class MrAndersonV1ApiController {
       @Valid @RequestParam(value = "page", required = false, defaultValue = "1") @Min(1) int page,
       @Valid @RequestParam(value = "_count", required = false, defaultValue = "15") @Min(0)
           int count,
-      ServerWebExchange exchange) {
+      @RequestParam MultiValueMap<String, String> allQueryParams) {
 
     String xml =
         resources.search(
@@ -72,7 +72,7 @@ public class MrAndersonV1ApiController {
                 .version(resourceVersion)
                 .page(page)
                 .count(count)
-                .parameters(exchange.getRequest().getQueryParams())
+                .parameters(allQueryParams)
                 .build());
 
     return ResponseEntity.ok().body(xml);

--- a/mr-anderson/src/test/java/gov/va/api/health/mranderson/controller/ErrorResponseTest.java
+++ b/mr-anderson/src/test/java/gov/va/api/health/mranderson/controller/ErrorResponseTest.java
@@ -1,0 +1,34 @@
+package gov.va.api.health.mranderson.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.va.api.health.autoconfig.configuration.JacksonConfig;
+import lombok.SneakyThrows;
+import org.junit.Test;
+
+public class ErrorResponseTest {
+
+  @Test
+  public void errorResponse() {
+    roundTrip(new ErrorResponse());
+    roundTrip(ErrorResponse.builder().message("halp").timestamp(80085).type("halpful").build());
+  }
+
+  @Test
+  public void fromException() {
+    ErrorResponse halp = ErrorResponse.of(new RuntimeException("halp"));
+    assertThat(halp.message()).isEqualTo("halp");
+    assertThat(halp.type()).isEqualTo("RuntimeException");
+  }
+
+  @SneakyThrows
+  private <T> T roundTrip(T object) {
+    ObjectMapper mapper = new JacksonConfig().objectMapper();
+    String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
+    Object evilTwin = mapper.readValue(json, object.getClass());
+    assertThat(evilTwin).isEqualTo(object);
+    assertThat(evilTwin.hashCode()).isEqualTo(object.hashCode());
+    return object;
+  }
+}

--- a/mr-anderson/src/test/java/gov/va/api/health/mranderson/controller/MrAndersonHomeControllerTest.java
+++ b/mr-anderson/src/test/java/gov/va/api/health/mranderson/controller/MrAndersonHomeControllerTest.java
@@ -1,6 +1,10 @@
 package gov.va.api.health.mranderson.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import gov.va.api.health.mranderson.cdw.Resources;
 import java.nio.charset.StandardCharsets;
@@ -8,62 +12,43 @@ import lombok.SneakyThrows;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.StreamUtils;
 
 @RunWith(SpringRunner.class)
-@WebFluxTest
+@WebMvcTest(controllers = {MrAndersonHomeController.class})
 public class MrAndersonHomeControllerTest {
   @MockBean Resources resources;
 
-  @Autowired private WebTestClient client;
-
-  @Test
-  @SneakyThrows
-  public void openapiYaml() {
-    byte[] responseBody =
-        client
-            .get()
-            .uri("/openapi.yaml")
-            .exchange()
-            .expectStatus()
-            .isOk()
-            .expectBody()
-            .returnResult()
-            .getResponseBody();
-
-    assertThat(new String(responseBody, StandardCharsets.UTF_8))
-        .isEqualTo(
-            StreamUtils.copyToString(
-                getClass().getResourceAsStream("/api-v1.yaml"), StandardCharsets.UTF_8));
-  }
+  @Autowired private MockMvc mvc;
 
   @Test
   @SneakyThrows
   public void openapiJson() {
-    client
-        .get()
-        .uri("/openapi.json")
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody()
-        .jsonPath("$.openapi", "3.0.1");
+    mvc.perform(get("/openapi.json"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.openapi", equalTo("3.0.1")));
+  }
+
+  @Test
+  @SneakyThrows
+  public void openapiYaml() {
+    String expected =
+        StreamUtils.copyToString(
+            getClass().getResourceAsStream("/api-v1.yaml"), StandardCharsets.UTF_8);
+    mvc.perform(get("/openapi.yaml"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(equalTo(expected)));
   }
 
   @Test
   @SneakyThrows
   public void openapiYamlFromIndex() {
-    client
-        .get()
-        .uri("/")
-        .exchange()
-        .expectStatus()
-        .isTemporaryRedirect()
-        .expectHeader()
-        .valueMatches("Location", ".*/openapi.json");
+    mvc.perform(get("/"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.openapi", equalTo("3.0.1")));
   }
 }

--- a/mr-anderson/src/test/java/gov/va/api/health/mranderson/controller/MrAndersonV1ApiControllerTest.java
+++ b/mr-anderson/src/test/java/gov/va/api/health/mranderson/controller/MrAndersonV1ApiControllerTest.java
@@ -13,15 +13,11 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.web.server.ServerWebExchange;
+import org.springframework.util.MultiValueMap;
 
 public class MrAndersonV1ApiControllerTest {
 
   @Mock Resources resources;
-
-  @Mock ServerWebExchange exchange;
-  @Mock ServerHttpRequest request;
 
   MrAndersonV1ApiController controller;
 
@@ -45,9 +41,8 @@ public class MrAndersonV1ApiControllerTest {
   @Test
   public void searchesAreForwardedToResourceRepository() {
     when(resources.search(Mockito.any())).thenReturn(Samples.create().patient());
-    when(exchange.getRequest()).thenReturn(request);
-    when(request.getQueryParams()).thenReturn(Parameters.builder().add("identity", "123").build());
-    controller.queryResourceVersion(Profile.ARGONAUT, "Patient", "1.01", 1, 15, exchange);
+    MultiValueMap<String, String> params = Parameters.builder().add("identity", "123").build();
+    controller.queryResourceVersion(Profile.ARGONAUT, "Patient", "1.01", 1, 15, params);
     verify(resources).search(query());
   }
 }

--- a/mr-anderson/src/test/java/gov/va/api/health/mranderson/controller/WebExceptionHandlerTest.java
+++ b/mr-anderson/src/test/java/gov/va/api/health/mranderson/controller/WebExceptionHandlerTest.java
@@ -1,7 +1,12 @@
 package gov.va.api.health.mranderson.controller;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import gov.va.api.health.autoconfig.configuration.JacksonConfig;
 import gov.va.api.health.ids.api.IdentityService.LookupFailed;
 import gov.va.api.health.ids.api.IdentityService.RegistrationFailed;
 import gov.va.api.health.ids.api.IdentityService.UnknownIdentity;
@@ -13,32 +18,38 @@ import gov.va.api.health.mranderson.cdw.Resources.SearchFailed;
 import gov.va.api.health.mranderson.cdw.Resources.UnknownIdentityInSearchParameter;
 import gov.va.api.health.mranderson.cdw.Resources.UnknownResource;
 import gov.va.api.health.mranderson.util.Parameters;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import javax.validation.ConstraintViolationException;
-import org.junit.ClassRule;
-import org.junit.Rule;
+import lombok.SneakyThrows;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
+import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.MockitoAnnotations;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
-import org.springframework.test.web.reactive.server.WebTestClient;
-import org.springframework.test.web.reactive.server.WebTestClient.BodySpec;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
+import org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod;
 
 @RunWith(Parameterized.class)
-@WebFluxTest
 public class WebExceptionHandlerTest {
-
-  @ClassRule public static final SpringClassRule spring = new SpringClassRule();
-  @Rule public final SpringMethodRule springMethod = new SpringMethodRule();
 
   @Parameter(0)
   public HttpStatus status;
@@ -46,8 +57,11 @@ public class WebExceptionHandlerTest {
   @Parameter(1)
   public Exception exception;
 
-  @MockBean Resources resources;
-  @Autowired private WebTestClient client;
+  @Mock ServerWebExchange exchange;
+  @Mock ServerHttpRequest request;
+  @Mock Resources resources;
+  WebExceptionHandler exceptionHandler;
+  MrAndersonV1ApiController controller;
 
   @Parameterized.Parameters(name = "{index}:{0} - {1}")
   public static List<Object[]> parameters() {
@@ -78,20 +92,65 @@ public class WebExceptionHandlerTest {
     return new Object[] {status, exception};
   }
 
+  @Before
+  public void _init() {
+    MockitoAnnotations.initMocks(this);
+    controller = new MrAndersonV1ApiController(resources);
+    exceptionHandler = new WebExceptionHandler();
+  }
+
+  private HandlerMethodArgumentResolver argumentResolver() {
+    return new HandlerMethodArgumentResolver() {
+      @Override
+      public Object resolveArgument(
+          MethodParameter parameter,
+          ModelAndViewContainer mavContainer,
+          NativeWebRequest webRequest,
+          WebDataBinderFactory binderFactory) {
+        return exchange;
+      }
+
+      @Override
+      public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType() == ServerWebExchange.class;
+      }
+    };
+  }
+
+  private ExceptionHandlerExceptionResolver createExceptionResolver() {
+    ExceptionHandlerExceptionResolver exceptionResolver =
+        new ExceptionHandlerExceptionResolver() {
+          @Override
+          protected ServletInvocableHandlerMethod getExceptionHandlerMethod(
+              HandlerMethod handlerMethod, Exception exception) {
+            Method method =
+                new ExceptionHandlerMethodResolver(WebExceptionHandler.class)
+                    .resolveMethod(exception);
+            return new ServletInvocableHandlerMethod(exceptionHandler, method);
+          }
+        };
+    exceptionResolver
+        .getMessageConverters()
+        .add(new MappingJackson2HttpMessageConverter(JacksonConfig.createMapper()));
+    exceptionResolver.afterPropertiesSet();
+    return exceptionResolver;
+  }
+
   @Test
+  @SneakyThrows
   public void expectStatus() {
     when(resources.search(Mockito.any())).thenThrow(exception);
-    BodySpec<ErrorResponse, ?> body =
-        client
-            .get()
-            .uri("/api/v1/resources/argonaut/Patient/1.01?identity=123")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(status)
-            .expectBody(ErrorResponse.class);
-    ErrorResponse error = body.returnResult().getResponseBody();
-    error.hashCode();
-    error.toString();
-    error.equals(error);
+    when(exchange.getRequest()).thenReturn(request);
+    when(request.getQueryParams()).thenReturn(Parameters.empty());
+    MockMvc mvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .setCustomArgumentResolvers(argumentResolver())
+            .setHandlerExceptionResolvers(createExceptionResolver())
+            .setMessageConverters()
+            .build();
+
+    mvc.perform(get("/api/v1/resources/argonaut/Patient/1.01?identity=123"))
+        .andExpect(status().is(status.value()))
+        .andExpect(jsonPath("type", equalTo(exception.getClass().getSimpleName())));
   }
 }

--- a/mr-anderson/src/test/java/gov/va/api/health/mranderson/controller/WebExceptionHandlerTest.java
+++ b/mr-anderson/src/test/java/gov/va/api/health/mranderson/controller/WebExceptionHandlerTest.java
@@ -32,19 +32,12 @@ import org.junit.runners.Parameterized.Parameter;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.bind.support.WebDataBinderFactory;
-import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.method.support.ModelAndViewContainer;
-import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
 import org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod;
 
@@ -57,8 +50,6 @@ public class WebExceptionHandlerTest {
   @Parameter(1)
   public Exception exception;
 
-  @Mock ServerWebExchange exchange;
-  @Mock ServerHttpRequest request;
   @Mock Resources resources;
   WebExceptionHandler exceptionHandler;
   MrAndersonV1ApiController controller;
@@ -99,24 +90,6 @@ public class WebExceptionHandlerTest {
     exceptionHandler = new WebExceptionHandler();
   }
 
-  private HandlerMethodArgumentResolver argumentResolver() {
-    return new HandlerMethodArgumentResolver() {
-      @Override
-      public Object resolveArgument(
-          MethodParameter parameter,
-          ModelAndViewContainer mavContainer,
-          NativeWebRequest webRequest,
-          WebDataBinderFactory binderFactory) {
-        return exchange;
-      }
-
-      @Override
-      public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.getParameterType() == ServerWebExchange.class;
-      }
-    };
-  }
-
   private ExceptionHandlerExceptionResolver createExceptionResolver() {
     ExceptionHandlerExceptionResolver exceptionResolver =
         new ExceptionHandlerExceptionResolver() {
@@ -140,11 +113,8 @@ public class WebExceptionHandlerTest {
   @SneakyThrows
   public void expectStatus() {
     when(resources.search(Mockito.any())).thenThrow(exception);
-    when(exchange.getRequest()).thenReturn(request);
-    when(request.getQueryParams()).thenReturn(Parameters.empty());
     MockMvc mvc =
         MockMvcBuilders.standaloneSetup(controller)
-            .setCustomArgumentResolvers(argumentResolver())
             .setHandlerExceptionResolvers(createExceptionResolver())
             .setMessageConverters()
             .build();

--- a/sentinel/pom.xml
+++ b/sentinel/pom.xml
@@ -340,7 +340,7 @@
       <id>jenkins-config</id>
       <activation>
         <property>
-          <name>env.HEALTH_API_CERTIFICATE_PASSWORD</name>
+          <name>env.BUILD_ID</name>
         </property>
       </activation>
       <build>

--- a/service-auto-config/pom.xml
+++ b/service-auto-config/pom.xml
@@ -18,7 +18,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webflux</artifactId>
+      <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/service-starter/pom.xml
+++ b/service-starter/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>lombok</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/src/scripts/dev-app.sh
+++ b/src/scripts/dev-app.sh
@@ -31,7 +31,7 @@ exit 1
 startApp() {
   local app=$1
   local pid=$(pidOf $app)
-  [ -n $pid ] && echo "$app appears to already be running" && return
+  [ -n "$pid" ] && echo "$app appears to already be running ($pid)" && return
   echo "Starting $app"
   cd $REPO/$app
   local jar=$(find target -maxdepth 1 -name "$app-*.jar" | head -1)


### PR DESCRIPTION
`server.ssl.key-alias` support now works as expected!

Root cause: `service-starter` drug in a webflux dependency which interfered with the standard MVC servlet engine from properly configuring SSL. All traces of WebFlux have been removed, which impacted many of the spring-related tests.

This story can be validated by using different values for the `server.ssl.key-alias` key alias property, e.g.  `internal-sys-dev` and `internal-sys-vaqa`. `curl -v` or `openssl` can be used to see these changes.


Curl will display something like this:
```
$ curl -vk https://localhost:8089/actuator/health
... lots of stuff ...
* Server certificate:
*  subject: C=US; ST=Florida; L=Melbourne; O=Liberty IT Solutions; OU=DVP; CN=localhost
... lots of stuff ...
```

OpenSSL will display something like this:
```
$ echo quit | openssl s_client  -connect localhost:8089 -servername localhost -status
... lots of stuff ...
subject=/C=US/ST=Florida/L=Melbourne/O=Liberty IT Solutions/OU=DVP/CN=localhost
... lots of stuff ...
```

Running these commands with different aliases will produce different results. Fun alternative path, you can specify an alias that doesn't exist and the app will fail to start.