### PR TITLE
trust-dev-certs.sh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,7 @@
   <distributionManagement>
     <repository>
       <id>health-apis-releases</id>
-      <url>http://internal-devtoolsinternalalb-1479233608.us-gov-west-1.elb.amazonaws.com/nexus/repository/health-apis-releases/</url>
+      <url>https://tools.health.dev-developer.va.gov/nexus/repository/health-apis-releases/</url>
     </repository>
   </distributionManagement>
 </project>

--- a/src/scripts/trust-dev-certs.sh
+++ b/src/scripts/trust-dev-certs.sh
@@ -26,6 +26,23 @@ BACKUP=$(basename "$TRUST_STORE").$(date +%s)
 cp "$TRUST_STORE" "$BACKUP"
 echo -e "Backed up $TRUST_STORE\nto $(pwd)/$BACKUP"
 
+OLD=$(keytool \
+  -list \
+  -alias $ALIAS \
+  -keypass "$HEALTH_API_CERTIFICATE_PASSWORD" \
+  -keystore "$TRUST_STORE" \
+  -storepass "$TRUST_STORE_PASSWORD")
+if [ -n "$OLD" ]
+then
+  echo "Removing old $ALIAS trusted certificate"
+  keytool \
+    -delete \
+    -alias $ALIAS \
+    -keypass "$HEALTH_API_CERTIFICATE_PASSWORD" \
+    -keystore "$TRUST_STORE" \
+    -storepass "$TRUST_STORE_PASSWORD"
+fi
+
 keytool \
   -exportcert \
   -storepass "$HEALTH_API_CERTIFICATE_PASSWORD" \


### PR DESCRIPTION
- Now replaces previously trusted `internal-sys-dev` instead of failing if it already exists.