### PR TITLE
Health check fixes

### DIFF
--- a/argonaut/src/main/resources/application.properties
+++ b/argonaut/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 server.port=8090
 mranderson.url=unset
 argonaut.url=unset
+health-check.medication-id=unset
 security.require-ssl=true
 server.ssl.key-store-type=JKS
 server.ssl.key-store=unset
@@ -13,9 +14,8 @@ management.endpoint.env.enabled=true
 management.endpoint.metrics.enabled=true
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=health,info,env,metrics,prometheus
-spring.jackson.default-property-inclusion=non_empty
 management.endpoint.health.show-details=ALWAYS
 management.health.diskspace.enabled=false
-health.id=unset
+spring.jackson.default-property-inclusion=non_empty
 
 

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/healthcheck/SteelThreadHealthCheckTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/healthcheck/SteelThreadHealthCheckTest.java
@@ -15,7 +15,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.actuate.health.Status;
 
-public class HealthCheckTest {
+public class SteelThreadHealthCheckTest {
   @Mock MrAndersonClient client;
 
   @Before

--- a/sentinel/pom.xml
+++ b/sentinel/pom.xml
@@ -241,6 +241,7 @@
                 <argument>-Dloader.path=sentinel-${project.version}.jar</argument>
                 <argument>-Dloader=gov.va.api.health.argonaut.service.Application</argument>
                 <argument>-Dmranderson.url=https://localhost:8088</argument>
+                <argument>-Dhealth-check.medication-id=skip</argument>
                 <argument>-Dserver.ssl.key-store=file:certs/system/DVP-DVP-NONPROD.jks</argument>
                 <argument>-Dserver.ssl.key-alias=internal-sys-dev</argument>
                 <argument>-Dssl.verify=false</argument>

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/HealthCheckIT.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/HealthCheckIT.java
@@ -1,0 +1,41 @@
+package gov.va.health.api.sentinel;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import org.junit.Test;
+
+public class HealthCheckIT {
+
+  @Test
+  public void argonautIsHealthy() {
+    Sentinel.get()
+        .clients()
+        .argonaut()
+        .get("/actuator/health")
+        .response()
+        .then()
+        .body("status", equalTo("UP"));
+  }
+
+  @Test
+  public void idsIsHealthy() {
+    Sentinel.get()
+        .clients()
+        .ids()
+        .get("/actuator/health")
+        .response()
+        .then()
+        .body("status", equalTo("UP"));
+  }
+
+  @Test
+  public void mrAndersonIsHealthy() {
+    Sentinel.get()
+        .clients()
+        .mrAnderson()
+        .get("/actuator/health")
+        .response()
+        .then()
+        .body("status", equalTo("UP"));
+  }
+}

--- a/src/scripts/make-configs.sh
+++ b/src/scripts/make-configs.sh
@@ -130,6 +130,7 @@ checkForUnsetValues mr-anderson $PROFILE
 makeConfig argonaut $PROFILE
 configValue argonaut $PROFILE mranderson.url https://localhost:8088
 configValue argonaut $PROFILE argonaut.url https://localhost:8090 
+configValue argonaut $PROFILE health-check.medication-id 2f773f73-ad7f-56ca-891e-8e364c913fe0
 checkForUnsetValues argonaut $PROFILE
 
 makeSentinelSecrets


### PR DESCRIPTION
Fixes health checks preventing applications for starting with Sentinel.

Changes
- Renamed `health.id` to `health-check.medication-id` to more clearly describe what it is
- `health-check.medication-id` supports the value `skip` to skip the interacting with downstream services
- Update `make-configs` to set `health-check.medication-id` to a value usable with Sandbox
- Sentinel now explicitly skips steel thread health checks
- Steel thread health check now properly catches HTTP client exceptions and reports
  service as `DOWN` instead of returning a `404` and an OperationOutcome