### PR TITLE
Argonaut fully qualified reference links

### DIFF
--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/config/ArgonautJacksonMapper.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/config/ArgonautJacksonMapper.java
@@ -1,0 +1,112 @@
+package gov.va.api.health.argonaut.service.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import gov.va.api.health.argonaut.api.elements.Reference;
+import gov.va.api.health.autoconfig.configuration.JacksonConfig;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * This mapper provides additional configuration that treats Argonaut Reference objects special. It
+ * will fully qualify relative reference links.
+ */
+@Slf4j
+@Configuration
+public class ArgonautJacksonMapper {
+
+  /**
+   * The published URL for argonaut, which is likely not the hostname of the machine running this
+   * application.
+   */
+  private final String baseUrl;
+
+  /** These base path for resources, e.g. api */
+  private String basePath;
+
+  @Autowired
+  public ArgonautJacksonMapper(
+      @Value("${argonaut.url}") String baseUrl, @Value("${argonaut.base-path}") String basePath) {
+    this.baseUrl = baseUrl;
+    this.basePath = basePath;
+  }
+
+  /**
+   * Return a ready to use mapper that will work with classes adhering to the conventions described
+   * in the class-level documentation.
+   */
+  @Bean
+  public ObjectMapper objectMapper() {
+    ObjectMapper mapper = JacksonConfig.createMapper();
+    mapper.registerModule(new QualifiedReferenceModule());
+    return mapper;
+  }
+
+  private class QualifiedReferenceModule extends SimpleModule {
+
+    @Override
+    public void setupModule(SetupContext context) {
+      super.setupModule(context);
+      context.addBeanSerializerModifier(
+          new BeanSerializerModifier() {
+            @Override
+            public List<BeanPropertyWriter> changeProperties(
+                SerializationConfig config,
+                BeanDescription beanDesc,
+                List<BeanPropertyWriter> beanProperties) {
+              if (beanDesc.getBeanClass() == Reference.class) {
+                for (int i = 0; i < beanProperties.size(); i++) {
+                  BeanPropertyWriter beanPropertyWriter = beanProperties.get(i);
+                  if ("reference".equals(beanPropertyWriter.getName())) {
+                    beanProperties.set(i, new QualifiedReferenceWriter(beanPropertyWriter));
+                  }
+                }
+              }
+              return super.changeProperties(config, beanDesc, beanProperties);
+            }
+          });
+    }
+  }
+
+  private class QualifiedReferenceWriter extends BeanPropertyWriter {
+
+    private QualifiedReferenceWriter(BeanPropertyWriter base) {
+      super(base);
+    }
+
+    private String qualify(String reference) {
+      if (StringUtils.isBlank(reference)) {
+        return null;
+      }
+      if (reference.startsWith("http")) {
+        return reference;
+      }
+      if (reference.startsWith("/")) {
+        return baseUrl + "/" + basePath + reference;
+      }
+      return baseUrl + "/" + basePath + "/" + reference;
+    }
+
+    @Override
+    public void serializeAsField(
+        Object shouldBeReference, JsonGenerator gen, SerializerProvider prov) throws Exception {
+      if (!(shouldBeReference instanceof Reference)) {
+        throw new IllegalArgumentException(
+            "Qualified reference writer cannot serialize: " + shouldBeReference);
+      }
+      Reference reference = (Reference) shouldBeReference;
+      gen.writeStringField(getName(), qualify(reference.reference()));
+    }
+  }
+}

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/ConfigurableBaseUrlPageLinks.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/ConfigurableBaseUrlPageLinks.java
@@ -25,10 +25,14 @@ public class ConfigurableBaseUrlPageLinks implements PageLinks {
    * application.
    */
   private final String baseUrl;
+  /** These base path for resources, e.g. api */
+  private String basePath;
 
   @Autowired
-  public ConfigurableBaseUrlPageLinks(@Value("${argonaut.url}") String baseUrl) {
+  public ConfigurableBaseUrlPageLinks(
+      @Value("${argonaut.url}") String baseUrl, @Value("${argonaut.base-path}") String basePath) {
     this.baseUrl = baseUrl;
+    this.basePath = basePath;
   }
 
   @Override
@@ -49,7 +53,7 @@ public class ConfigurableBaseUrlPageLinks implements PageLinks {
 
   @Override
   public String readLink(String resourcePath, String id) {
-    return baseUrl + resourcePath + "/" + id;
+    return baseUrl + "/" + basePath + "/" + resourcePath + "/" + id;
   }
 
   /** This context wraps the link state to allow link creation to be clearly described. */
@@ -97,7 +101,7 @@ public class ConfigurableBaseUrlPageLinks implements PageLinks {
       MultiValueMap<String, String> mutableParams = new LinkedMultiValueMap<>(config.queryParams());
       mutableParams.remove("page");
       mutableParams.remove("_count");
-      StringBuilder msg = new StringBuilder(baseUrl);
+      StringBuilder msg = new StringBuilder(baseUrl).append('/').append(basePath).append('/');
       msg.append(config.path()).append('?');
       String params =
           mutableParams

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/allergyintolerance/AllergyIntoleranceController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/allergyintolerance/AllergyIntoleranceController.java
@@ -16,7 +16,6 @@ import gov.va.api.health.argonaut.service.mranderson.client.Query;
 import gov.va.dvp.cdw.xsd.model.CdwAllergyIntolerance103Root;
 import java.util.Collections;
 import java.util.function.Function;
-import javax.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,15 +47,11 @@ public class AllergyIntoleranceController {
   private MrAndersonClient mrAndersonClient;
   private Bundler bundler;
 
-  private Bundle bundle(
-      MultiValueMap<String, String> parameters,
-      int page,
-      int count,
-      HttpServletRequest servletRequest) {
+  private Bundle bundle(MultiValueMap<String, String> parameters, int page, int count) {
     CdwAllergyIntolerance103Root root = search(parameters);
     LinkConfig linkConfig =
         LinkConfig.builder()
-            .path(servletRequest.getRequestURI())
+            .path("AllergyIntolerance")
             .queryParams(parameters)
             .page(page)
             .recordsPerPage(count)
@@ -100,13 +95,11 @@ public class AllergyIntoleranceController {
   public AllergyIntolerance.Bundle searchById(
       @RequestParam("_id") String id,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "1") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
     return bundle(
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by identifier. */
@@ -114,8 +107,7 @@ public class AllergyIntoleranceController {
   public AllergyIntolerance.Bundle searchByIdentifier(
       @RequestParam("identifier") String identifier,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "1") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
     return bundle(
         Parameters.builder()
             .add("identifier", identifier)
@@ -123,8 +115,7 @@ public class AllergyIntoleranceController {
             .add("_count", count)
             .build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by patient. */
@@ -132,13 +123,11 @@ public class AllergyIntoleranceController {
   public AllergyIntolerance.Bundle searchByPatient(
       @RequestParam("patient") String patient,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder().add("patient", patient).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Hey, this is a validate endpoint. It validates. */

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/diagnosticreport/DiagnosticReportController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/diagnosticreport/DiagnosticReportController.java
@@ -17,7 +17,6 @@ import gov.va.dvp.cdw.xsd.model.CdwDiagnosticReport102Root;
 import gov.va.dvp.cdw.xsd.model.CdwDiagnosticReport102Root.CdwDiagnosticReports.CdwDiagnosticReport;
 import java.util.Collections;
 import java.util.function.Function;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,15 +49,11 @@ public class DiagnosticReportController {
   private MrAndersonClient mrAndersonClient;
   private Bundler bundler;
 
-  private Bundle bundle(
-      MultiValueMap<String, String> parameters,
-      int page,
-      int count,
-      HttpServletRequest servletRequest) {
+  private Bundle bundle(MultiValueMap<String, String> parameters, int page, int count) {
     CdwDiagnosticReport102Root root = search(parameters);
     LinkConfig linkConfig =
         LinkConfig.builder()
-            .path(servletRequest.getRequestURI())
+            .path("DiagnosticReport")
             .queryParams(parameters)
             .page(page)
             .recordsPerPage(count)
@@ -102,13 +97,11 @@ public class DiagnosticReportController {
   public DiagnosticReport.Bundle searchById(
       @RequestParam("_id") String id,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by identifier. */
@@ -116,8 +109,7 @@ public class DiagnosticReportController {
   public DiagnosticReport.Bundle searchByIdentifier(
       @RequestParam("identifier") String identifier,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder()
             .add("identifier", identifier)
@@ -125,8 +117,7 @@ public class DiagnosticReportController {
             .add("_count", count)
             .build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by patient. */
@@ -134,13 +125,11 @@ public class DiagnosticReportController {
   public DiagnosticReport.Bundle searchByPatient(
       @RequestParam("patient") String patient,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder().add("patient", patient).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by Patient+Category. */
@@ -149,8 +138,7 @@ public class DiagnosticReportController {
       @RequestParam("patient") String patient,
       @RequestParam("category") String category,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder()
             .add("patient", patient)
@@ -159,28 +147,7 @@ public class DiagnosticReportController {
             .add("_count", count)
             .build(),
         page,
-        count,
-        servletRequest);
-  }
-
-  /** Search by Patient+Code. */
-  @GetMapping(params = {"patient", "code"})
-  public DiagnosticReport.Bundle searchByPatientAndCode(
-      @RequestParam("patient") String patient,
-      @RequestParam("code") String code,
-      @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
-    return bundle(
-        Parameters.builder()
-            .add("patient", patient)
-            .add("code", code)
-            .add("page", page)
-            .add("_count", count)
-            .build(),
-        page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by Patient+Category+Date. */
@@ -190,8 +157,7 @@ public class DiagnosticReportController {
       @RequestParam("code") String code,
       @RequestParam(value = "date", required = false) @Size(max = 2) String[] date,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder()
             .add("patient", patient)
@@ -201,8 +167,25 @@ public class DiagnosticReportController {
             .add("_count", count)
             .build(),
         page,
-        count,
-        servletRequest);
+        count);
+  }
+
+  /** Search by Patient+Code. */
+  @GetMapping(params = {"patient", "code"})
+  public DiagnosticReport.Bundle searchByPatientAndCode(
+      @RequestParam("patient") String patient,
+      @RequestParam("code") String code,
+      @RequestParam(value = "page", defaultValue = "1") int page,
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
+    return bundle(
+        Parameters.builder()
+            .add("patient", patient)
+            .add("code", code)
+            .add("page", page)
+            .add("_count", count)
+            .build(),
+        page,
+        count);
   }
 
   /** Validate Endpoint. */

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/encounter/EncounterController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/encounter/EncounterController.java
@@ -15,7 +15,6 @@ import gov.va.api.health.argonaut.service.mranderson.client.Query;
 import gov.va.dvp.cdw.xsd.model.CdwEncounter101Root;
 import java.util.Collections;
 import java.util.function.Function;
-import javax.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,15 +45,11 @@ public class EncounterController {
   private MrAndersonClient mrAndersonClient;
   private Bundler bundler;
 
-  private Encounter.Bundle bundle(
-      MultiValueMap<String, String> parameters,
-      int page,
-      int count,
-      HttpServletRequest servletRequest) {
+  private Encounter.Bundle bundle(MultiValueMap<String, String> parameters, int page, int count) {
     CdwEncounter101Root root = search(parameters);
     LinkConfig linkConfig =
         LinkConfig.builder()
-            .path(servletRequest.getRequestURI())
+            .path("Encounter")
             .queryParams(parameters)
             .page(page)
             .recordsPerPage(count)
@@ -96,13 +91,11 @@ public class EncounterController {
   public Encounter.Bundle searchById(
       @RequestParam("_id") String id,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "1") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
     return bundle(
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by Identifier. */
@@ -110,13 +103,11 @@ public class EncounterController {
   public Encounter.Bundle searchByIdentifier(
       @RequestParam("identifier") String id,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "1") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
     return bundle(
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Hey, this is a validate endpoint. It validates. */

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/immunization/ImmunizationController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/immunization/ImmunizationController.java
@@ -15,7 +15,6 @@ import gov.va.api.health.argonaut.service.mranderson.client.Query;
 import gov.va.dvp.cdw.xsd.model.CdwImmunization103Root;
 import java.util.Collections;
 import java.util.function.Function;
-import javax.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,15 +47,12 @@ public class ImmunizationController {
   private Bundler bundler;
 
   private Immunization.Bundle bundle(
-      MultiValueMap<String, String> parameters,
-      int page,
-      int count,
-      HttpServletRequest servletRequest) {
+      MultiValueMap<String, String> parameters, int page, int count) {
 
     CdwImmunization103Root root = search(parameters);
     LinkConfig linkConfig =
         LinkConfig.builder()
-            .path(servletRequest.getRequestURI())
+            .path("Immunization")
             .queryParams(parameters)
             .page(page)
             .recordsPerPage(count)
@@ -99,13 +95,11 @@ public class ImmunizationController {
   public Immunization.Bundle searchById(
       @RequestParam("_id") String id,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "1") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
     return bundle(
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by Identifier. */
@@ -113,13 +107,11 @@ public class ImmunizationController {
   public Immunization.Bundle searchByIdentifier(
       @RequestParam("identifier") String id,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "1") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
     return bundle(
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by patient. */
@@ -127,13 +119,11 @@ public class ImmunizationController {
   public Immunization.Bundle searchByPatient(
       @RequestParam("patient") String patient,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder().add("patient", patient).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Hey, this is a validate endpoint. It validates. */

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/medication/MedicationController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/medication/MedicationController.java
@@ -15,7 +15,6 @@ import gov.va.api.health.argonaut.service.mranderson.client.Query;
 import gov.va.dvp.cdw.xsd.model.CdwMedication101Root;
 import java.util.Collections;
 import java.util.function.Function;
-import javax.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,15 +46,11 @@ public class MedicationController {
   private MrAndersonClient mrAndersonClient;
   private Bundler bundler;
 
-  private Medication.Bundle bundle(
-      MultiValueMap<String, String> parameters,
-      int page,
-      int count,
-      HttpServletRequest servletRequest) {
+  private Medication.Bundle bundle(MultiValueMap<String, String> parameters, int page, int count) {
     CdwMedication101Root root = search(parameters);
     LinkConfig linkConfig =
         LinkConfig.builder()
-            .path(servletRequest.getRequestURI())
+            .path("Medication")
             .queryParams(parameters)
             .page(page)
             .recordsPerPage(count)
@@ -97,13 +92,11 @@ public class MedicationController {
   public Medication.Bundle searchById(
       @RequestParam("_id") String id,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "1") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
     return bundle(
         Parameters.builder().add("_id", id).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by Identifier. */
@@ -111,13 +104,11 @@ public class MedicationController {
   public Medication.Bundle searchByIdentifier(
       @RequestParam("identifier") String id,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "1") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
     return bundle(
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Hey, this is a validate endpoint. It validates. */

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/observation/ObservationController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/observation/ObservationController.java
@@ -15,7 +15,6 @@ import gov.va.api.health.argonaut.service.mranderson.client.Query;
 import gov.va.dvp.cdw.xsd.model.CdwObservation104Root;
 import java.util.Collections;
 import java.util.function.Function;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,16 +47,12 @@ public class ObservationController {
   private MrAndersonClient mrAndersonClient;
   private Bundler bundler;
 
-  private Observation.Bundle bundle(
-      MultiValueMap<String, String> parameters,
-      int page,
-      int count,
-      HttpServletRequest servletRequest) {
+  private Observation.Bundle bundle(MultiValueMap<String, String> parameters, int page, int count) {
 
     CdwObservation104Root root = search(parameters);
     LinkConfig linkConfig =
         LinkConfig.builder()
-            .path(servletRequest.getRequestURI())
+            .path("Observation")
             .queryParams(parameters)
             .page(page)
             .recordsPerPage(count)
@@ -100,13 +95,11 @@ public class ObservationController {
   public Observation.Bundle searchById(
       @RequestParam("_id") String id,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "1") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
     return bundle(
         Parameters.builder().add("_id", id).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by Identifier. */
@@ -114,13 +107,11 @@ public class ObservationController {
   public Observation.Bundle searchByIdentifier(
       @RequestParam("identifier") String id,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "1") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
     return bundle(
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by patient. */
@@ -128,13 +119,11 @@ public class ObservationController {
   public Observation.Bundle searchByPatient(
       @RequestParam("patient") String patient,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder().add("patient", patient).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by patient and category and data if available. */
@@ -144,8 +133,7 @@ public class ObservationController {
       @RequestParam("category") String category,
       @RequestParam(value = "date", required = false) @Size(max = 2) String[] date,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder()
             .add("patient", patient)
@@ -155,8 +143,7 @@ public class ObservationController {
             .add("_count", count)
             .build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by patient and category and data if available. */
@@ -165,8 +152,7 @@ public class ObservationController {
       @RequestParam("patient") String patient,
       @RequestParam("code") String code,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder()
             .add("patient", patient)
@@ -175,8 +161,7 @@ public class ObservationController {
             .add("_count", count)
             .build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Hey, this is a validate endpoint. It validates. */

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/patient/PatientController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/patient/PatientController.java
@@ -17,7 +17,6 @@ import gov.va.dvp.cdw.xsd.model.CdwPatient103Root;
 import gov.va.dvp.cdw.xsd.model.CdwPatient103Root.CdwPatients.CdwPatient;
 import java.util.Collections;
 import java.util.function.Function;
-import javax.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,15 +48,11 @@ public class PatientController {
   private MrAndersonClient mrAndersonClient;
   private Bundler bundler;
 
-  private Bundle bundle(
-      MultiValueMap<String, String> parameters,
-      int page,
-      int count,
-      HttpServletRequest servletRequest) {
+  private Bundle bundle(MultiValueMap<String, String> parameters, int page, int count) {
     CdwPatient103Root root = search(parameters);
     LinkConfig linkConfig =
         LinkConfig.builder()
-            .path(servletRequest.getRequestURI())
+            .path("Patient")
             .queryParams(parameters)
             .page(page)
             .recordsPerPage(count)
@@ -97,8 +92,7 @@ public class PatientController {
       @RequestParam("family") String family,
       @RequestParam("gender") String gender,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
 
     return bundle(
         Parameters.builder()
@@ -108,8 +102,7 @@ public class PatientController {
             .add("_count", count)
             .build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by Given+Gender. */
@@ -118,8 +111,7 @@ public class PatientController {
       @RequestParam("given") String given,
       @RequestParam("gender") String gender,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder()
             .add("given", given)
@@ -128,8 +120,7 @@ public class PatientController {
             .add("_count", count)
             .build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by _id. */
@@ -137,13 +128,11 @@ public class PatientController {
   public Patient.Bundle searchById(
       @RequestParam("_id") String id,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "1") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
     return bundle(
         Parameters.builder().add("_id", id).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by Identifier. */
@@ -151,13 +140,11 @@ public class PatientController {
   public Patient.Bundle searchByIdentifier(
       @RequestParam("identifier") String id,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "1") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
     return bundle(
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by Name+Birthdate. */
@@ -166,8 +153,7 @@ public class PatientController {
       @RequestParam("name") String name,
       @RequestParam("birthdate") String[] birthdate,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder()
             .add("name", name)
@@ -176,8 +162,7 @@ public class PatientController {
             .add("_count", count)
             .build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Search by Name+Gender. */
@@ -186,8 +171,7 @@ public class PatientController {
       @RequestParam("name") String name,
       @RequestParam("gender") String gender,
       @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "_count", defaultValue = "15") int count,
-      HttpServletRequest servletRequest) {
+      @RequestParam(value = "_count", defaultValue = "15") int count) {
     return bundle(
         Parameters.builder()
             .add("name", name)
@@ -196,8 +180,7 @@ public class PatientController {
             .add("_count", count)
             .build(),
         page,
-        count,
-        servletRequest);
+        count);
   }
 
   /** Hey, this is a validate endpoint. It validates. */

--- a/argonaut/src/main/resources/application.properties
+++ b/argonaut/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 server.port=8090
 mranderson.url=unset
 argonaut.url=unset
+argonaut.base-path=api
 health-check.medication-id=unset
 security.require-ssl=true
 server.ssl.key-store-type=JKS

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/config/ArgonautJacksonMapperTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/config/ArgonautJacksonMapperTest.java
@@ -1,0 +1,83 @@
+package gov.va.api.health.argonaut.service.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import gov.va.api.health.argonaut.api.elements.Reference;
+import gov.va.api.health.autoconfig.configuration.JacksonConfig;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Singular;
+import lombok.SneakyThrows;
+import org.junit.Test;
+
+public class ArgonautJacksonMapperTest {
+
+  private Reference reference(String path) {
+    return Reference.builder().display("display").reference(path).id("id").build();
+  }
+
+  @Test
+  @SneakyThrows
+  public void referencesAreQualified() {
+    FugaziReferencemajig input =
+        FugaziReferencemajig.builder()
+            .whocares("noone")
+            .me(true)
+            .ref(reference("r1"))
+            .thing(reference(null))
+            .thing(reference(""))
+            .thing(reference("http://qualified.is.not/touched"))
+            .thing(reference("no/slash"))
+            .thing(reference("/cool/a/slash"))
+            .inner(FugaziReferencemajig.builder().ref(reference("me/too")).build())
+            .build();
+
+    FugaziReferencemajig expected =
+        FugaziReferencemajig.builder()
+            .whocares("noone")
+            .me(true)
+            .ref(reference("https://example.com/api/r1"))
+            .thing(reference(null))
+            .thing(reference(null))
+            .thing(reference("http://qualified.is.not/touched"))
+            .thing(reference("https://example.com/api/no/slash"))
+            .thing(reference("https://example.com/api/cool/a/slash"))
+            .inner(
+                FugaziReferencemajig.builder()
+                    .ref(reference("https://example.com/api/me/too"))
+                    .build())
+            .build();
+
+    String qualifiedJson =
+        new ArgonautJacksonMapper("https://example.com", "api")
+            .objectMapper()
+            .writeValueAsString(input);
+
+    FugaziReferencemajig actual =
+        JacksonConfig.createMapper().readValue(qualifiedJson, FugaziReferencemajig.class);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(
+    fieldVisibility = JsonAutoDetect.Visibility.ANY,
+    isGetterVisibility = Visibility.NONE
+  )
+  public static class FugaziReferencemajig {
+    Reference ref;
+    @Singular List<Reference> things;
+    FugaziReferencemajig inner;
+    String whocares;
+    Boolean me;
+  }
+}

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/ConfigurableBaseUrlPageLinksTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/ConfigurableBaseUrlPageLinksTest.java
@@ -15,7 +15,7 @@ public class ConfigurableBaseUrlPageLinksTest {
 
   @Before
   public void _init() {
-    links = new ConfigurableBaseUrlPageLinks("https://awesome.com");
+    links = new ConfigurableBaseUrlPageLinks("https://awesome.com", "api");
   }
 
   @Test
@@ -32,7 +32,7 @@ public class ConfigurableBaseUrlPageLinksTest {
 
   private LinkConfig forCurrentPage(int page, int count, int total) {
     return LinkConfig.builder()
-        .path("/api/Whatever")
+        .path("Whatever")
         .queryParams(
             Parameters.builder()
                 .add("a", "apple")
@@ -97,7 +97,6 @@ public class ConfigurableBaseUrlPageLinksTest {
 
   @Test
   public void readLinkCombinesConfiguredUrl() {
-    assertThat(links.readLink("/api/Whatever", "123"))
-        .isEqualTo("https://awesome.com/api/Whatever/123");
+    assertThat(links.readLink("Whatever", "123")).isEqualTo("https://awesome.com/api/Whatever/123");
   }
 }

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/allergyintolerance/AllergyIntoleranceControllerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/allergyintolerance/AllergyIntoleranceControllerTest.java
@@ -22,7 +22,6 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Supplier;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
 import lombok.SneakyThrows;
 import org.junit.Before;
@@ -39,7 +38,6 @@ public class AllergyIntoleranceControllerTest {
   @Mock AllergyIntoleranceController.Transformer tx;
 
   AllergyIntoleranceController controller;
-  @Mock HttpServletRequest servletRequest;
   @Mock Bundler bundler;
 
   @Before
@@ -68,7 +66,6 @@ public class AllergyIntoleranceControllerTest {
     when(tx.apply(xmlAllergyIntolerance2)).thenReturn(allergyIntolerance2);
     when(tx.apply(xmlAllergyIntolerance3)).thenReturn(allergyIntolerance3);
     when(client.search(Mockito.any())).thenReturn(root);
-    when(servletRequest.getRequestURI()).thenReturn("/api/AllergyIntolerance");
 
     Bundle mockBundle = new Bundle();
     when(bundler.bundle(Mockito.any())).thenReturn(mockBundle);
@@ -89,7 +86,7 @@ public class AllergyIntoleranceControllerTest {
             .page(1)
             .recordsPerPage(10)
             .totalRecords(3)
-            .path("/api/AllergyIntolerance")
+            .path("AllergyIntolerance")
             .queryParams(params)
             .build();
     assertThat(captor.getValue().linkConfig()).isEqualTo(expectedLinkConfig);
@@ -135,21 +132,21 @@ public class AllergyIntoleranceControllerTest {
   @Test
   public void searchById() {
     assertSearch(
-        () -> controller.searchById("me", 1, 10, servletRequest),
+        () -> controller.searchById("me", 1, 10),
         Parameters.builder().add("identifier", "me").add("page", 1).add("_count", 10).build());
   }
 
   @Test
   public void searchByIdentifier() {
     assertSearch(
-        () -> controller.searchByIdentifier("me", 1, 10, servletRequest),
+        () -> controller.searchByIdentifier("me", 1, 10),
         Parameters.builder().add("identifier", "me").add("page", 1).add("_count", 10).build());
   }
 
   @Test
   public void searchByPatient() {
     assertSearch(
-        () -> controller.searchByPatient("me", 1, 10, servletRequest),
+        () -> controller.searchByPatient("me", 1, 10),
         Parameters.builder().add("patient", "me").add("page", 1).add("_count", 10).build());
   }
 
@@ -160,10 +157,9 @@ public class AllergyIntoleranceControllerTest {
     root.setRecordsPerPage(BigInteger.valueOf(10));
     root.setRecordCount(BigInteger.valueOf(0));
     when(client.search(Mockito.any())).thenReturn(root);
-    when(servletRequest.getRequestURI()).thenReturn("/api/AllergyIntolerance");
     Bundle mockBundle = new Bundle();
     when(bundler.bundle(Mockito.any())).thenReturn(mockBundle);
-    Bundle actual = controller.searchById("me", 1, 10, servletRequest);
+    Bundle actual = controller.searchById("me", 1, 10);
     assertThat(actual).isSameAs(mockBundle);
     @SuppressWarnings("unchecked")
     ArgumentCaptor<
@@ -178,7 +174,7 @@ public class AllergyIntoleranceControllerTest {
             .page(1)
             .recordsPerPage(10)
             .totalRecords(0)
-            .path("/api/AllergyIntolerance")
+            .path("AllergyIntolerance")
             .queryParams(
                 Parameters.builder()
                     .add("identifier", "me")

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/encounter/EncounterControllerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/encounter/EncounterControllerTest.java
@@ -22,7 +22,6 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Supplier;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
 import lombok.SneakyThrows;
 import org.junit.Before;
@@ -40,7 +39,6 @@ public class EncounterControllerTest {
   @Mock EncounterController.Transformer tx;
 
   EncounterController controller;
-  @Mock HttpServletRequest servletRequest;
   @Mock Bundler bundler;
 
   @Before
@@ -67,7 +65,6 @@ public class EncounterControllerTest {
     when(tx.apply(cdwItem2)).thenReturn(patient2);
     when(tx.apply(cdwItem3)).thenReturn(patient3);
     when(client.search(Mockito.any())).thenReturn(root);
-    when(servletRequest.getRequestURI()).thenReturn("/api/Patient");
 
     Encounter.Bundle mockBundle = new Encounter.Bundle();
     when(bundler.bundle(Mockito.any())).thenReturn(mockBundle);
@@ -86,7 +83,7 @@ public class EncounterControllerTest {
             .page(1)
             .recordsPerPage(10)
             .totalRecords(3)
-            .path("/api/Patient")
+            .path("Encounter")
             .queryParams(params)
             .build();
     assertThat(captor.getValue().linkConfig()).isEqualTo(expectedLinkConfig);
@@ -127,14 +124,14 @@ public class EncounterControllerTest {
   @Test
   public void searchById() {
     assertSearch(
-        () -> controller.searchById("me", 1, 10, servletRequest),
+        () -> controller.searchById("me", 1, 10),
         Parameters.builder().add("identifier", "me").add("page", 1).add("_count", 10).build());
   }
 
   @Test
   public void searchByIdentifier() {
     assertSearch(
-        () -> controller.searchByIdentifier("me", 1, 10, servletRequest),
+        () -> controller.searchByIdentifier("me", 1, 10),
         Parameters.builder().add("identifier", "me").add("page", 1).add("_count", 10).build());
   }
 

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/immunization/ImmunizationControllerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/immunization/ImmunizationControllerTest.java
@@ -22,7 +22,6 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Supplier;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
 import lombok.SneakyThrows;
 import org.junit.Before;
@@ -40,7 +39,6 @@ public class ImmunizationControllerTest {
   @Mock ImmunizationController.Transformer tx;
 
   ImmunizationController controller;
-  @Mock HttpServletRequest servletRequest;
   @Mock Bundler bundler;
 
   @Before
@@ -66,7 +64,6 @@ public class ImmunizationControllerTest {
     when(tx.apply(cdwItem2)).thenReturn(patient2);
     when(tx.apply(cdwItem3)).thenReturn(patient3);
     when(client.search(Mockito.any())).thenReturn(root);
-    when(servletRequest.getRequestURI()).thenReturn("/api/Patient");
 
     Bundle mockBundle = new Bundle();
     when(bundler.bundle(Mockito.any())).thenReturn(mockBundle);
@@ -85,7 +82,7 @@ public class ImmunizationControllerTest {
             .page(1)
             .recordsPerPage(10)
             .totalRecords(3)
-            .path("/api/Patient")
+            .path("Immunization")
             .queryParams(params)
             .build();
     assertThat(captor.getValue().linkConfig()).isEqualTo(expectedLinkConfig);
@@ -128,21 +125,21 @@ public class ImmunizationControllerTest {
   @Test
   public void searchById() {
     assertSearch(
-        () -> controller.searchById("me", 1, 10, servletRequest),
+        () -> controller.searchById("me", 1, 10),
         Parameters.builder().add("identifier", "me").add("page", 1).add("_count", 10).build());
   }
 
   @Test
   public void searchByIdentifier() {
     assertSearch(
-        () -> controller.searchByIdentifier("me", 1, 10, servletRequest),
+        () -> controller.searchByIdentifier("me", 1, 10),
         Parameters.builder().add("identifier", "me").add("page", 1).add("_count", 10).build());
   }
 
   @Test
   public void searchByPatient() {
     assertSearch(
-        () -> controller.searchByPatient("me", 1, 10, servletRequest),
+        () -> controller.searchByPatient("me", 1, 10),
         Parameters.builder().add("patient", "me").add("page", 1).add("_count", 10).build());
   }
 

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/medication/MedicationControllerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/medication/MedicationControllerTest.java
@@ -22,7 +22,6 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Supplier;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
 import lombok.SneakyThrows;
 import org.junit.Before;
@@ -40,7 +39,6 @@ public class MedicationControllerTest {
   @Mock MedicationController.Transformer tx;
 
   MedicationController controller;
-  @Mock HttpServletRequest servletRequest;
   @Mock Bundler bundler;
 
   @Before
@@ -69,7 +67,6 @@ public class MedicationControllerTest {
     when(tx.apply(xmlPatient2)).thenReturn(patient2);
     when(tx.apply(xmlPatient3)).thenReturn(patient3);
     when(client.search(Mockito.any())).thenReturn(root);
-    when(servletRequest.getRequestURI()).thenReturn("/api/Patient");
 
     Medication.Bundle mockBundle = new Medication.Bundle();
     when(bundler.bundle(Mockito.any())).thenReturn(mockBundle);
@@ -88,7 +85,7 @@ public class MedicationControllerTest {
             .page(1)
             .recordsPerPage(10)
             .totalRecords(3)
-            .path("/api/Patient")
+            .path("Medication")
             .queryParams(params)
             .build();
     assertThat(captor.getValue().linkConfig()).isEqualTo(expectedLinkConfig);
@@ -132,14 +129,14 @@ public class MedicationControllerTest {
   @Test
   public void searchById() {
     assertSearch(
-        () -> controller.searchById("me", 1, 10, servletRequest),
+        () -> controller.searchById("me", 1, 10),
         Parameters.builder().add("_id", "me").add("page", 1).add("_count", 10).build());
   }
 
   @Test
   public void searchByIdentifier() {
     assertSearch(
-        () -> controller.searchByIdentifier("me", 1, 10, servletRequest),
+        () -> controller.searchByIdentifier("me", 1, 10),
         Parameters.builder().add("identifier", "me").add("page", 1).add("_count", 10).build());
   }
 

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/observation/ObservationControllerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/observation/ObservationControllerTest.java
@@ -22,7 +22,6 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Supplier;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
 import lombok.SneakyThrows;
 import org.junit.Before;
@@ -40,7 +39,6 @@ public class ObservationControllerTest {
   @Mock ObservationController.Transformer tx;
 
   ObservationController controller;
-  @Mock HttpServletRequest servletRequest;
   @Mock Bundler bundler;
 
   @Before
@@ -66,7 +64,6 @@ public class ObservationControllerTest {
     when(tx.apply(cdwItem2)).thenReturn(patient2);
     when(tx.apply(cdwItem3)).thenReturn(patient3);
     when(client.search(Mockito.any())).thenReturn(root);
-    when(servletRequest.getRequestURI()).thenReturn("/api/Patient");
 
     Bundle mockBundle = new Bundle();
     when(bundler.bundle(Mockito.any())).thenReturn(mockBundle);
@@ -85,7 +82,7 @@ public class ObservationControllerTest {
             .page(1)
             .recordsPerPage(10)
             .totalRecords(3)
-            .path("/api/Patient")
+            .path("Observation")
             .queryParams(params)
             .build();
     assertThat(captor.getValue().linkConfig()).isEqualTo(expectedLinkConfig);
@@ -128,21 +125,21 @@ public class ObservationControllerTest {
   @Test
   public void searchById() {
     assertSearch(
-        () -> controller.searchById("me", 1, 10, servletRequest),
+        () -> controller.searchById("me", 1, 10),
         Parameters.builder().add("_id", "me").add("page", 1).add("_count", 10).build());
   }
 
   @Test
   public void searchByIdentifier() {
     assertSearch(
-        () -> controller.searchByIdentifier("me", 1, 10, servletRequest),
+        () -> controller.searchByIdentifier("me", 1, 10),
         Parameters.builder().add("identifier", "me").add("page", 1).add("_count", 10).build());
   }
 
   @Test
   public void searchByPatient() {
     assertSearch(
-        () -> controller.searchByPatient("me", 1, 10, servletRequest),
+        () -> controller.searchByPatient("me", 1, 10),
         Parameters.builder().add("patient", "me").add("page", 1).add("_count", 10).build());
   }
 
@@ -151,12 +148,7 @@ public class ObservationControllerTest {
     assertSearch(
         () ->
             controller.searchByPatientAndCategory(
-                "me",
-                "laboratory,vital-signs",
-                new String[] {"2005", "2006"},
-                1,
-                10,
-                servletRequest),
+                "me", "laboratory,vital-signs", new String[] {"2005", "2006"}, 1, 10),
         Parameters.builder()
             .add("patient", "me")
             .add("category", "laboratory,vital-signs")
@@ -169,9 +161,7 @@ public class ObservationControllerTest {
   @Test
   public void searchByPatientAndCategoryNoDate() {
     assertSearch(
-        () ->
-            controller.searchByPatientAndCategory(
-                "me", "laboratory,vital-signs", null, 1, 10, servletRequest),
+        () -> controller.searchByPatientAndCategory("me", "laboratory,vital-signs", null, 1, 10),
         Parameters.builder()
             .add("patient", "me")
             .add("category", "laboratory,vital-signs")
@@ -185,7 +175,7 @@ public class ObservationControllerTest {
     assertSearch(
         () ->
             controller.searchByPatientAndCategory(
-                "me", "laboratory,vital-signs", new String[] {"2005"}, 1, 10, servletRequest),
+                "me", "laboratory,vital-signs", new String[] {"2005"}, 1, 10),
         Parameters.builder()
             .add("patient", "me")
             .add("category", "laboratory,vital-signs")
@@ -198,7 +188,7 @@ public class ObservationControllerTest {
   @Test
   public void searchByPatientAndCode() {
     assertSearch(
-        () -> controller.searchByPatientAndCode("me", "123,456", 1, 10, servletRequest),
+        () -> controller.searchByPatientAndCode("me", "123,456", 1, 10),
         Parameters.builder()
             .add("patient", "me")
             .add("code", "123,456")

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/observation/ObservationTransformerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/observation/ObservationTransformerTest.java
@@ -36,6 +36,7 @@ import java.math.BigInteger;
 import java.util.List;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import org.junit.Test;
@@ -172,8 +173,8 @@ public class ObservationTransformerTest {
     assertThat(tx.valueQuantity(cdw.valueQuantity())).isEqualTo(expected.valueQuantity());
   }
 
-  @NoArgsConstructor(staticName = "get")
-  private static class CdwSampleData {
+  @NoArgsConstructor(staticName = "get", access = AccessLevel.PUBLIC)
+  public static class CdwSampleData {
 
     private CdwCategory category() {
       CdwCategory cdw = new CdwCategory();
@@ -286,7 +287,7 @@ public class ObservationTransformerTest {
       return cdw;
     }
 
-    CdwObservation observation() {
+    public CdwObservation observation() {
       CdwObservation cdw = new CdwObservation();
       cdw.setRowNumber(BigInteger.ONE);
       cdw.setCdwId("1201051417263:V");
@@ -378,7 +379,7 @@ public class ObservationTransformerTest {
   }
 
   @NoArgsConstructor(staticName = "get")
-  private static class Expected {
+  public static class Expected {
 
     CodeableConcept category() {
       return codeableConcept(
@@ -457,7 +458,7 @@ public class ObservationTransformerTest {
       return codeableConcept(coding("http://hl7.org/fhir/v2/0078", "L", "Low")).text("L");
     }
 
-    Observation observation() {
+    public Observation observation() {
       return Observation.builder()
           .resourceType("Observation")
           .id("1201051417263:V")

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/patient/PatientControllerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/patient/PatientControllerTest.java
@@ -21,7 +21,6 @@ import gov.va.dvp.cdw.xsd.model.CdwPatient103Root.CdwPatients.CdwPatient;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Supplier;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
 import lombok.SneakyThrows;
 import org.junit.Before;
@@ -38,7 +37,6 @@ public class PatientControllerTest {
   @Mock MrAndersonClient client;
   @Mock PatientController.Transformer tx;
   @Mock Bundler bundler;
-  @Mock HttpServletRequest servletRequest;
 
   PatientController controller;
 
@@ -65,7 +63,6 @@ public class PatientControllerTest {
     when(tx.apply(xmlPatient2)).thenReturn(patient2);
     when(tx.apply(xmlPatient3)).thenReturn(patient3);
     when(client.search(Mockito.any())).thenReturn(root);
-    when(servletRequest.getRequestURI()).thenReturn("/api/Patient");
 
     Bundle mockBundle = new Bundle();
     when(bundler.bundle(Mockito.any())).thenReturn(mockBundle);
@@ -84,7 +81,7 @@ public class PatientControllerTest {
             .page(1)
             .recordsPerPage(10)
             .totalRecords(3)
-            .path("/api/Patient")
+            .path("Patient")
             .queryParams(params)
             .build();
     assertThat(captor.getValue().linkConfig()).isEqualTo(expectedLinkConfig);
@@ -124,7 +121,7 @@ public class PatientControllerTest {
   @Test
   public void searchByFamilyAndGender() {
     assertSearch(
-        () -> controller.searchByFamilyAndGender("f", "g", 1, 10, servletRequest),
+        () -> controller.searchByFamilyAndGender("f", "g", 1, 10),
         Parameters.builder()
             .add("family", "f")
             .add("gender", "g")
@@ -136,7 +133,7 @@ public class PatientControllerTest {
   @Test
   public void searchByGivenAndGender() {
     assertSearch(
-        () -> controller.searchByGivenAndGender("f", "g", 1, 10, servletRequest),
+        () -> controller.searchByGivenAndGender("f", "g", 1, 10),
         Parameters.builder()
             .add("given", "f")
             .add("gender", "g")
@@ -148,23 +145,21 @@ public class PatientControllerTest {
   @Test
   public void searchById() {
     assertSearch(
-        () -> controller.searchById("me", 1, 10, servletRequest),
+        () -> controller.searchById("me", 1, 10),
         Parameters.builder().add("_id", "me").add("page", 1).add("_count", 10).build());
   }
 
   @Test
   public void searchByIdentifier() {
     assertSearch(
-        () -> controller.searchByIdentifier("me", 1, 10, servletRequest),
+        () -> controller.searchByIdentifier("me", 1, 10),
         Parameters.builder().add("identifier", "me").add("page", 1).add("_count", 10).build());
   }
 
   @Test
   public void searchByNameAndBirthdate() {
     assertSearch(
-        () ->
-            controller.searchByNameAndBirthdate(
-                "me", new String[] {"1975", "2005"}, 1, 10, servletRequest),
+        () -> controller.searchByNameAndBirthdate("me", new String[] {"1975", "2005"}, 1, 10),
         Parameters.builder()
             .add("name", "me")
             .addAll("birthdate", "1975", "2005")
@@ -176,7 +171,7 @@ public class PatientControllerTest {
   @Test
   public void searchByNameAndGender() {
     assertSearch(
-        () -> controller.searchByNameAndGender("f", "g", 1, 10, servletRequest),
+        () -> controller.searchByNameAndGender("f", "g", 1, 10),
         Parameters.builder()
             .add("name", "f")
             .add("gender", "g")
@@ -192,10 +187,9 @@ public class PatientControllerTest {
     root.setRecordsPerPage(10);
     root.setRecordCount(0);
     when(client.search(Mockito.any())).thenReturn(root);
-    when(servletRequest.getRequestURI()).thenReturn("/api/Patient");
     Bundle mockBundle = new Bundle();
     when(bundler.bundle(Mockito.any())).thenReturn(mockBundle);
-    Bundle actual = controller.searchById("me", 1, 10, servletRequest);
+    Bundle actual = controller.searchById("me", 1, 10);
     assertThat(actual).isSameAs(mockBundle);
     @SuppressWarnings("unchecked")
     ArgumentCaptor<BundleContext<CdwPatient, Patient, Patient.Entry, Patient.Bundle>> captor =
@@ -207,7 +201,7 @@ public class PatientControllerTest {
             .page(1)
             .recordsPerPage(10)
             .totalRecords(0)
-            .path("/api/Patient")
+            .path("Patient")
             .queryParams(
                 Parameters.builder().add("_id", "me").add("page", 1).add("_count", 10).build())
             .build();

--- a/service-auto-config/src/main/java/gov/va/api/health/autoconfig/configuration/JacksonConfig.java
+++ b/service-auto-config/src/main/java/gov/va/api/health/autoconfig/configuration/JacksonConfig.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -101,6 +102,7 @@ public class JacksonConfig {
    * in the class-level documentation.
    */
   @Bean
+  @ConditionalOnMissingBean
   public ObjectMapper objectMapper() {
     return configureMapper(new ObjectMapper());
   }


### PR DESCRIPTION
- Adds new Jackson ObjectMapper constomizations that will fully qualify references during serialization.
- Adds new `argonaut.base-path` configurable to account for lab environment where base path isn't `api`
- Changes the way bundle links are created such that they no longer take the full request URI, but rather just the resource name.