### PR TITLE
Task/API 430 Practitioner Read Search Validate Sentinel

### DIFF
--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/config/ArgonautJacksonMapper.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/config/ArgonautJacksonMapper.java
@@ -106,7 +106,10 @@ public class ArgonautJacksonMapper {
             "Qualified reference writer cannot serialize: " + shouldBeReference);
       }
       Reference reference = (Reference) shouldBeReference;
-      gen.writeStringField(getName(), qualify(reference.reference()));
+      String qualifiedReference = qualify(reference.reference());
+      if (qualifiedReference != null) {
+        gen.writeStringField(getName(), qualifiedReference);
+      }
     }
   }
 }

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerController.java
@@ -1,0 +1,61 @@
+package gov.va.api.health.argonaut.service.controller.practitioner;
+
+import static gov.va.api.health.argonaut.service.controller.Transformers.firstPayloadItem;
+import static gov.va.api.health.argonaut.service.controller.Transformers.hasPayload;
+
+import gov.va.api.health.argonaut.api.resources.Practitioner;
+import gov.va.api.health.argonaut.service.controller.Parameters;
+import gov.va.api.health.argonaut.service.mranderson.client.MrAndersonClient;
+import gov.va.api.health.argonaut.service.mranderson.client.Query;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root;
+import java.util.function.Function;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Request Mappings for the Argonaut Practitioner Profile, see
+ * http://hl7.org/fhir/DSTU2/practitioner.html for implementation details.
+ */
+@SuppressWarnings("WeakerAccess")
+@RestController
+@RequestMapping(
+  value = {"/api/Practitioner"},
+  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
+)
+@AllArgsConstructor(onConstructor = @__({@Autowired}))
+@Slf4j
+public class PractitionerController {
+
+  private Transformer transformer;
+  private MrAndersonClient mrAndersonClient;
+
+  /** Read by id. */
+  @GetMapping(value = {"/{publicId}"})
+  public Practitioner read(@PathVariable("publicId") String publicId) {
+
+    return transformer.apply(
+        firstPayloadItem(
+            hasPayload(
+                search(Parameters.forIdentity(publicId)).getPractitioners().getPractitioner())));
+  }
+
+  private CdwPractitioner100Root search(MultiValueMap<String, String> params) {
+    Query<CdwPractitioner100Root> query =
+        Query.forType(CdwPractitioner100Root.class)
+            .profile(Query.Profile.ARGONAUT)
+            .resource("Practitioner")
+            .version("1.00")
+            .parameters(params)
+            .build();
+    return mrAndersonClient.search(query);
+  }
+
+  public interface Transformer
+      extends Function<CdwPractitioner100Root.CdwPractitioners.CdwPractitioner, Practitioner> {}
+}

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerController.java
@@ -3,11 +3,18 @@ package gov.va.api.health.argonaut.service.controller.practitioner;
 import static gov.va.api.health.argonaut.service.controller.Transformers.firstPayloadItem;
 import static gov.va.api.health.argonaut.service.controller.Transformers.hasPayload;
 
+import gov.va.api.health.argonaut.api.resources.OperationOutcome;
 import gov.va.api.health.argonaut.api.resources.Practitioner;
+import gov.va.api.health.argonaut.service.controller.Bundler;
+import gov.va.api.health.argonaut.service.controller.Bundler.BundleContext;
+import gov.va.api.health.argonaut.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.argonaut.service.controller.Parameters;
+import gov.va.api.health.argonaut.service.controller.Validator;
 import gov.va.api.health.argonaut.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.argonaut.service.mranderson.client.Query;
+import gov.va.api.health.argonaut.service.mranderson.client.Query.Profile;
 import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root;
+import java.util.Collections;
 import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +22,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -34,6 +44,30 @@ public class PractitionerController {
 
   private Transformer transformer;
   private MrAndersonClient mrAndersonClient;
+  private Bundler bundler;
+
+  private Practitioner.Bundle bundle(
+      MultiValueMap<String, String> parameters, int page, int count) {
+
+    CdwPractitioner100Root root = search(parameters);
+    LinkConfig linkConfig =
+        LinkConfig.builder()
+            .path("Practitioner")
+            .queryParams(parameters)
+            .page(page)
+            .recordsPerPage(count)
+            .totalRecords(root.getRecordCount().intValue())
+            .build();
+    return bundler.bundle(
+        BundleContext.of(
+            linkConfig,
+            root.getPractitioners() == null
+                ? Collections.emptyList()
+                : root.getPractitioners().getPractitioner(),
+            transformer,
+            Practitioner.Entry::new,
+            Practitioner.Bundle::new));
+  }
 
   /** Read by id. */
   @GetMapping(value = {"/{publicId}"})
@@ -48,12 +82,33 @@ public class PractitionerController {
   private CdwPractitioner100Root search(MultiValueMap<String, String> params) {
     Query<CdwPractitioner100Root> query =
         Query.forType(CdwPractitioner100Root.class)
-            .profile(Query.Profile.ARGONAUT)
+            .profile(Profile.DSTU2)
             .resource("Practitioner")
             .version("1.00")
             .parameters(params)
             .build();
     return mrAndersonClient.search(query);
+  }
+
+  /** Search by _id. */
+  @GetMapping(params = {"_id"})
+  public Practitioner.Bundle searchById(
+      @RequestParam("_id") String id,
+      @RequestParam(value = "page", defaultValue = "1") int page,
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
+    return bundle(
+        Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
+        page,
+        count);
+  }
+
+  /** Hey, this is a validate endpoint. It validates. */
+  @PostMapping(
+    value = "/$validate",
+    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
+  )
+  public OperationOutcome validate(@RequestBody Practitioner.Bundle bundle) {
+    return Validator.create().validate(bundle);
   }
 
   public interface Transformer

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerController.java
@@ -102,6 +102,18 @@ public class PractitionerController {
         count);
   }
 
+  /** Search by Identifier. */
+  @GetMapping(params = {"identifier"})
+  public Practitioner.Bundle searchByIdentifier(
+      @RequestParam("identifier") String id,
+      @RequestParam(value = "page", defaultValue = "1") int page,
+      @RequestParam(value = "_count", defaultValue = "1") int count) {
+    return bundle(
+        Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
+        page,
+        count);
+  }
+
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
     value = "/$validate",

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerTransformer.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerTransformer.java
@@ -43,9 +43,6 @@ public class PractitionerTransformer implements PractitionerController.Transform
   }
 
   List<Address> addresses(CdwAddresses optionalSource) {
-    if (optionalSource == null || optionalSource.getAddress().isEmpty()) {
-      return null;
-    }
     return convertAll(
         ifPresent(optionalSource, CdwAddresses::getAddress),
         cdw ->
@@ -66,18 +63,12 @@ public class PractitionerTransformer implements PractitionerController.Transform
   }
 
   List<Reference> healthcareService(CdwHealthcareServices source) {
-    if (source == null || source.getHealthcareService() == null) {
-      return null;
-    }
     return convertAll(
         ifPresent(source, CdwHealthcareServices::getHealthcareService),
         cdw -> Reference.builder().display(cdw.getDisplay()).reference(cdw.getReference()).build());
   }
 
   List<Reference> locations(CdwLocations source) {
-    if (source == null || source.getLocation() == null) {
-      return null;
-    }
     return convertAll(
         ifPresent(source, CdwLocations::getLocation),
         cdw -> Reference.builder().display(cdw.getDisplay()).reference(cdw.getReference()).build());
@@ -109,11 +100,18 @@ public class PractitionerTransformer implements PractitionerController.Transform
             HumanName.builder()
                 .use(ifPresent(cdw.getUse(), use -> HumanName.NameUse.valueOf(use.value())))
                 .text(cdw.getText())
-                .family(singletonList(cdw.getFamily()))
-                .given(singletonList(cdw.getGiven()))
-                .suffix(singletonList(cdw.getSuffix()))
-                .prefix(singletonList(cdw.getPrefix()))
+                .family(nameList(cdw.getFamily()))
+                .given(nameList(cdw.getGiven()))
+                .suffix(nameList(cdw.getSuffix()))
+                .prefix(nameList(cdw.getPrefix()))
                 .build());
+  }
+
+  List<String> nameList(String source) {
+    if (source == null) {
+      return null;
+    }
+    return singletonList(source);
   }
 
   private Practitioner practitioner(CdwPractitioner source) {
@@ -188,9 +186,6 @@ public class PractitionerTransformer implements PractitionerController.Transform
   }
 
   List<ContactPoint> telecoms(CdwTelecoms optionalSource) {
-    if (optionalSource == null || optionalSource.getTelecom().isEmpty()) {
-      return null;
-    }
     return convertAll(
         ifPresent(optionalSource, CdwTelecoms::getTelecom),
         cdw ->

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerTransformer.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerTransformer.java
@@ -1,0 +1,191 @@
+package gov.va.api.health.argonaut.service.controller.practitioner;
+
+import static gov.va.api.health.argonaut.service.controller.Transformers.allNull;
+import static gov.va.api.health.argonaut.service.controller.Transformers.asDateTimeString;
+import static gov.va.api.health.argonaut.service.controller.Transformers.convertAll;
+import static gov.va.api.health.argonaut.service.controller.Transformers.ifPresent;
+
+import gov.va.api.health.argonaut.api.datatypes.Address;
+import gov.va.api.health.argonaut.api.datatypes.CodeableConcept;
+import gov.va.api.health.argonaut.api.datatypes.Coding;
+import gov.va.api.health.argonaut.api.datatypes.ContactPoint;
+import gov.va.api.health.argonaut.api.datatypes.HumanName;
+import gov.va.api.health.argonaut.api.elements.Reference;
+import gov.va.api.health.argonaut.api.resources.Practitioner;
+import gov.va.api.health.argonaut.api.resources.Practitioner.Gender;
+import gov.va.api.health.argonaut.api.resources.Practitioner.PractitionerRole;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwAddresses;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwName;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwPractitionerRoles;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwPractitionerRoles.CdwPractitionerRole;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwPractitionerRoles.CdwPractitionerRole.CdwHealthcareServices;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwPractitionerRoles.CdwPractitionerRole.CdwLocations;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwTelecoms;
+import gov.va.dvp.cdw.xsd.model.CdwPractitionerRoleCoding;
+import gov.va.dvp.cdw.xsd.model.CdwPractitionerRoleCoding.CdwCoding;
+import gov.va.dvp.cdw.xsd.model.CdwReference;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PractitionerTransformer implements PractitionerController.Transformer {
+
+  @Override
+  public Practitioner apply(CdwPractitioner source) {
+    return practitioner(source);
+  }
+
+  List<Address> addresses(CdwAddresses optionalSource) {
+    if (optionalSource == null || optionalSource.getAddress().isEmpty()) {
+      return null;
+    }
+    return convertAll(
+        ifPresent(optionalSource, CdwAddresses::getAddress),
+        cdw ->
+            Address.builder()
+                .line(cdw.getLines().getLine())
+                .city(cdw.getCity())
+                .state(cdw.getState())
+                .postalCode(cdw.getPostalCode())
+                .build());
+  }
+
+  List<Reference> healthcareService(CdwHealthcareServices source) {
+    if (source == null
+        || source.getHealthcareService() == null
+        || source.getHealthcareService().isEmpty()) {
+      return null;
+    }
+    return convertAll(
+        ifPresent(source, CdwHealthcareServices::getHealthcareService),
+        cdw -> Reference.builder().display(cdw.getDisplay()).reference(cdw.getReference()).build());
+  }
+
+  List<Reference> locations(CdwLocations source) {
+    if (source == null || source.getLocation().isEmpty() || source.getLocation() == null) {
+      return null;
+    }
+    return convertAll(
+        ifPresent(source, CdwLocations::getLocation),
+        cdw -> Reference.builder().display(cdw.getDisplay()).reference(cdw.getReference()).build());
+  }
+
+  Reference managingOrganization(CdwReference source) {
+    if (source == null || allNull(source.getReference(), source.getDisplay())) {
+      return null;
+    }
+    return Reference.builder()
+        .reference(source.getReference())
+        .display(source.getDisplay())
+        .build();
+  }
+
+  HumanName name(CdwName source) {
+    if (source == null
+        || allNull(
+            source.getFamily(),
+            source.getGiven(),
+            source.getPrefix(),
+            source.getSuffix(),
+            source.getText(),
+            source.getUse())) {
+      return null;
+    }
+    return HumanName.builder()
+        .use(ifPresent(source.getUse(), use -> HumanName.NameUse.valueOf(use.value())))
+        .text(source.getText())
+        .family(Collections.singletonList(source.getFamily()))
+        .given(Collections.singletonList(source.getGiven()))
+        .prefix(Collections.singletonList(source.getPrefix()))
+        .suffix(Collections.singletonList(source.getSuffix()))
+        .build();
+  }
+
+  private Practitioner practitioner(CdwPractitioner source) {
+    return Practitioner.builder()
+        .id(source.getCdwId())
+        .resourceType("Practitioner")
+        .active(source.isActive())
+        .name(name(source.getName()))
+        .telecom(telecoms(source.getTelecoms()))
+        .address(addresses(source.getAddresses()))
+        .gender(ifPresent(source.getGender(), gender -> Gender.valueOf(gender.value())))
+        .birthDate(asDateTimeString(source.getBirthDate()))
+        .practitionerRole(practitionerRoles(source.getPractitionerRoles()))
+        .build();
+  }
+
+  List<PractitionerRole> practitionerRoles(CdwPractitionerRoles source) {
+    if (source == null || source.getPractitionerRole() == null) {
+      return null;
+    }
+    List<PractitionerRole> practitionerRoles =
+        source
+            .getPractitionerRole()
+            .stream()
+            .map(this::practitionerRole)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    if (practitionerRoles.isEmpty()) {
+      return null;
+    }
+    return practitionerRoles;
+  }
+
+  PractitionerRole practitionerRole(CdwPractitionerRole source) {
+    if (source == null
+        || allNull(
+            source.getHealthcareServices(),
+            source.getLocations(),
+            source.getManagingOrganization(),
+            source.getRole())) {
+      return null;
+    }
+    return PractitionerRole.builder()
+        .healthcareService(healthcareService(source.getHealthcareServices()))
+        .location(locations(source.getLocations()))
+        .managingOrganization(managingOrganization(source.getManagingOrganization()))
+        .role(role(source.getRole()))
+        .build();
+  }
+
+  CodeableConcept role(CdwPractitionerRoleCoding source) {
+    if (source == null || source.getCoding() == null) {
+      return null;
+    }
+    return CodeableConcept.builder().coding(coding(source.getCoding())).build();
+  }
+
+  List<Coding> coding(CdwCoding source) {
+    if (source == null) {
+      return null;
+    }
+    return Collections.singletonList(
+        Coding.builder()
+            .code(ifPresent(source.getCode(), code -> String.valueOf(code.value())))
+            .build());
+  }
+
+  List<ContactPoint> telecoms(CdwTelecoms optionalSource) {
+    if (optionalSource == null || optionalSource.getTelecom().isEmpty()) {
+      return null;
+    }
+    return convertAll(
+        ifPresent(optionalSource, CdwTelecoms::getTelecom),
+        cdw ->
+            ContactPoint.builder()
+                .system(
+                    ifPresent(
+                        cdw.getSystem(),
+                        system -> ContactPoint.ContactPointSystem.valueOf(system.value())))
+                .value(cdw.getValue())
+                .use(
+                    ifPresent(
+                        cdw.getUse(), use -> ContactPoint.ContactPointUse.valueOf(use.value())))
+                .build());
+  }
+}

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerControllerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerControllerTest.java
@@ -1,0 +1,52 @@
+package gov.va.api.health.argonaut.service.controller.practitioner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import gov.va.api.health.argonaut.api.resources.Practitioner;
+import gov.va.api.health.argonaut.service.controller.Parameters;
+import gov.va.api.health.argonaut.service.mranderson.client.MrAndersonClient;
+import gov.va.api.health.argonaut.service.mranderson.client.Query;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+@SuppressWarnings("WeakerAccess")
+public class PractitionerControllerTest {
+
+  @Mock MrAndersonClient client;
+
+  @Mock PractitionerController.Transformer tx;
+
+  PractitionerController controller;
+
+  @Before
+  public void _init() {
+    MockitoAnnotations.initMocks(this);
+    controller = new PractitionerController(tx, client);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void read() {
+    CdwPractitioner100Root root = new CdwPractitioner100Root();
+    root.setPractitioners(new CdwPractitioners());
+    CdwPractitioner xmlPractitioner = new CdwPractitioner();
+    root.getPractitioners().getPractitioner().add(xmlPractitioner);
+    Practitioner item = Practitioner.builder().build();
+    when(client.search(Mockito.any())).thenReturn(root);
+    when(tx.apply(xmlPractitioner)).thenReturn(item);
+    Practitioner actual = controller.read("hello");
+    assertThat(actual).isSameAs(item);
+    ArgumentCaptor<Query<CdwPractitioner100Root>> captor = ArgumentCaptor.forClass(Query.class);
+    verify(client).search(captor.capture());
+    assertThat(captor.getValue().parameters()).isEqualTo(Parameters.forIdentity("hello"));
+  }
+}

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerControllerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.va.api.health.argonaut.api.resources.Practitioner;
+import gov.va.api.health.argonaut.service.controller.Bundler;
 import gov.va.api.health.argonaut.service.controller.Parameters;
 import gov.va.api.health.argonaut.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.argonaut.service.mranderson.client.Query;
@@ -26,11 +27,12 @@ public class PractitionerControllerTest {
   @Mock PractitionerController.Transformer tx;
 
   PractitionerController controller;
+  @Mock Bundler bundler;
 
   @Before
   public void _init() {
     MockitoAnnotations.initMocks(this);
-    controller = new PractitionerController(tx, client);
+    controller = new PractitionerController(tx, client, bundler);
   }
 
   @SuppressWarnings("unchecked")

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerControllerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerControllerTest.java
@@ -4,20 +4,34 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import gov.va.api.health.argonaut.api.bundle.AbstractBundle.BundleType;
 import gov.va.api.health.argonaut.api.resources.Practitioner;
+import gov.va.api.health.argonaut.api.resources.Practitioner.Bundle;
+import gov.va.api.health.argonaut.api.resources.Practitioner.Entry;
 import gov.va.api.health.argonaut.service.controller.Bundler;
+import gov.va.api.health.argonaut.service.controller.Bundler.BundleContext;
+import gov.va.api.health.argonaut.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.argonaut.service.controller.Parameters;
+import gov.va.api.health.argonaut.service.controller.Validator;
 import gov.va.api.health.argonaut.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.argonaut.service.mranderson.client.Query;
+import gov.va.api.health.autoconfig.configuration.JacksonConfig;
 import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root;
 import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners;
 import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.function.Supplier;
+import javax.validation.ConstraintViolationException;
+import lombok.SneakyThrows;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.util.MultiValueMap;
 
 @SuppressWarnings("WeakerAccess")
 public class PractitionerControllerTest {
@@ -35,6 +49,64 @@ public class PractitionerControllerTest {
     controller = new PractitionerController(tx, client, bundler);
   }
 
+  private void assertSearch(Supplier<Bundle> invocation, MultiValueMap<String, String> params) {
+    CdwPractitioner100Root root = new CdwPractitioner100Root();
+    root.setPageNumber(BigInteger.valueOf(1));
+    root.setRecordsPerPage(BigInteger.valueOf(10));
+    root.setRecordCount(BigInteger.valueOf(3));
+    root.setPractitioners(new CdwPractitioners());
+    CdwPractitioner cdwItem1 = new CdwPractitioner();
+    CdwPractitioner cdwItem2 = new CdwPractitioner();
+    CdwPractitioner cdwItem3 = new CdwPractitioner();
+    root.getPractitioners().getPractitioner().addAll(Arrays.asList(cdwItem1, cdwItem2, cdwItem3));
+    Practitioner practitioner1 = Practitioner.builder().build();
+    Practitioner practitioner2 = Practitioner.builder().build();
+    Practitioner practitioner3 = Practitioner.builder().build();
+    when(tx.apply(cdwItem1)).thenReturn(practitioner1);
+    when(tx.apply(cdwItem2)).thenReturn(practitioner2);
+    when(tx.apply(cdwItem3)).thenReturn(practitioner3);
+    when(client.search(Mockito.any())).thenReturn(root);
+
+    Bundle mockBundle = new Bundle();
+    when(bundler.bundle(Mockito.any())).thenReturn(mockBundle);
+
+    Bundle actual = invocation.get();
+
+    assertThat(actual).isSameAs(mockBundle);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<BundleContext<CdwPractitioner, Practitioner, Entry, Bundle>> captor =
+        ArgumentCaptor.forClass(BundleContext.class);
+
+    verify(bundler).bundle(captor.capture());
+
+    LinkConfig expectedLinkConfig =
+        LinkConfig.builder()
+            .page(1)
+            .recordsPerPage(10)
+            .totalRecords(3)
+            .path("Practitioner")
+            .queryParams(params)
+            .build();
+    assertThat(captor.getValue().linkConfig()).isEqualTo(expectedLinkConfig);
+    assertThat(captor.getValue().xmlItems()).isEqualTo(root.getPractitioners().getPractitioner());
+    assertThat(captor.getValue().newBundle().get()).isInstanceOf(Bundle.class);
+    assertThat(captor.getValue().newEntry().get()).isInstanceOf(Practitioner.Entry.class);
+    assertThat(captor.getValue().transformer()).isSameAs(tx);
+  }
+
+  private Bundle bundleOf(Practitioner resource) {
+    return Bundle.builder()
+        .type(BundleType.searchset)
+        .resourceType("Bundle")
+        .entry(
+            Collections.singletonList(
+                Practitioner.Entry.builder()
+                    .fullUrl("http://example.com")
+                    .resource(resource)
+                    .build()))
+        .build();
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void read() {
@@ -50,5 +122,46 @@ public class PractitionerControllerTest {
     ArgumentCaptor<Query<CdwPractitioner100Root>> captor = ArgumentCaptor.forClass(Query.class);
     verify(client).search(captor.capture());
     assertThat(captor.getValue().parameters()).isEqualTo(Parameters.forIdentity("hello"));
+  }
+
+  @Test
+  public void searchById() {
+    assertSearch(
+        () -> controller.searchById("me", 1, 10),
+        Parameters.builder().add("identifier", "me").add("page", 1).add("_count", 10).build());
+  }
+
+  @Test
+  public void searchByIdentifier() {
+    assertSearch(
+        () -> controller.searchByIdentifier("me", 1, 10),
+        Parameters.builder().add("identifier", "me").add("page", 1).add("_count", 10).build());
+  }
+
+  @Test
+  @SneakyThrows
+  public void validateAcceptsValidBundle() {
+    Practitioner resource =
+        JacksonConfig.createMapper()
+            .readValue(
+                getClass().getResourceAsStream("/cdw/old-practitioner-1.00.json"),
+                Practitioner.class);
+
+    Bundle bundle = bundleOf(resource);
+    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+  }
+
+  @Test(expected = ConstraintViolationException.class)
+  @SneakyThrows
+  public void validateThrowsExceptionForInvalidBundle() {
+    Practitioner resource =
+        JacksonConfig.createMapper()
+            .readValue(
+                getClass().getResourceAsStream("/cdw/old-practitioner-1.00.json"),
+                Practitioner.class);
+    resource.resourceType(null);
+
+    Bundle bundle = bundleOf(resource);
+    controller.validate(bundle);
   }
 }

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerTransformerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerTransformerTest.java
@@ -4,6 +4,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import gov.va.api.health.argonaut.api.datatypes.Address;
+import gov.va.api.health.argonaut.api.datatypes.Address.AddressUse;
 import gov.va.api.health.argonaut.api.datatypes.CodeableConcept;
 import gov.va.api.health.argonaut.api.datatypes.Coding;
 import gov.va.api.health.argonaut.api.datatypes.ContactPoint;
@@ -26,6 +27,7 @@ import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPract
 import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwPractitionerRoles.CdwPractitionerRole.CdwLocations;
 import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwTelecoms;
 import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwTelecoms.CdwTelecom;
+import gov.va.dvp.cdw.xsd.model.CdwPractitionerAddressUse;
 import gov.va.dvp.cdw.xsd.model.CdwPractitionerGender;
 import gov.va.dvp.cdw.xsd.model.CdwPractitionerNameUse;
 import gov.va.dvp.cdw.xsd.model.CdwPractitionerRoleCoding;
@@ -62,6 +64,22 @@ public class PractitionerTransformerTest {
   }
 
   @Test
+  public void addressUse() {
+    assertThat(tx.addressUse(CdwPractitionerAddressUse.HOME)).isEqualTo(AddressUse.home);
+    assertThat(tx.addressUse(CdwPractitionerAddressUse.OLD)).isEqualTo(AddressUse.old);
+    assertThat(tx.addressUse(CdwPractitionerAddressUse.TEMP)).isEqualTo(AddressUse.temp);
+    assertThat(tx.addressUse(CdwPractitionerAddressUse.WORK)).isEqualTo(AddressUse.work);
+  }
+
+  @Test
+  public void gender() {
+    assertThat(tx.gender(CdwPractitionerGender.FEMALE)).isEqualTo(Gender.female);
+    assertThat(tx.gender(CdwPractitionerGender.MALE)).isEqualTo(Gender.male);
+    assertThat(tx.gender(CdwPractitionerGender.OTHER)).isEqualTo(Gender.other);
+    assertThat(tx.gender(CdwPractitionerGender.UNKNOWN)).isEqualTo(Gender.unknown);
+  }
+
+  @Test
   public void healthcareServices() {
     assertThat(tx.healthcareService(null)).isNull();
     assertThat(tx.healthcareService(new CdwHealthcareServices())).isNull();
@@ -89,6 +107,17 @@ public class PractitionerTransformerTest {
     assertThat(tx.name(null)).isNull();
     assertThat(tx.name(new CdwName())).isNull();
     assertThat(tx.name(cdw.name())).isEqualTo(expected.name());
+  }
+
+  @Test
+  public void nameUse() {
+    assertThat(tx.nameUse(CdwPractitionerNameUse.ANONYMOUS)).isEqualTo(NameUse.anonymous);
+    assertThat(tx.nameUse(CdwPractitionerNameUse.MAIDEN)).isEqualTo(NameUse.maiden);
+    assertThat(tx.nameUse(CdwPractitionerNameUse.NICKNAME)).isEqualTo(NameUse.nickname);
+    assertThat(tx.nameUse(CdwPractitionerNameUse.OFFICIAL)).isEqualTo(NameUse.official);
+    assertThat(tx.nameUse(CdwPractitionerNameUse.OLD)).isEqualTo(NameUse.old);
+    assertThat(tx.nameUse(CdwPractitionerNameUse.TEMP)).isEqualTo(NameUse.temp);
+    assertThat(tx.nameUse(CdwPractitionerNameUse.USUAL)).isEqualTo(NameUse.usual);
   }
 
   @Test
@@ -128,6 +157,36 @@ public class PractitionerTransformerTest {
 
   @Test
   public void telecom() {
+    assertThat(tx.telecom(null)).isNull();
+    assertThat(tx.telecom(new CdwTelecom())).isNull();
+    assertThat(tx.telecom(cdw.telecom())).isEqualTo(expected.telecom());
+  }
+
+  @Test
+  public void telecomSystem() {
+    assertThat(tx.telecomSystem(CdwPractitionerTelecomSystem.EMAIL))
+        .isEqualTo(ContactPointSystem.email);
+    assertThat(tx.telecomSystem(CdwPractitionerTelecomSystem.FAX))
+        .isEqualTo(ContactPointSystem.fax);
+    assertThat(tx.telecomSystem(CdwPractitionerTelecomSystem.OTHER))
+        .isEqualTo(ContactPointSystem.other);
+    assertThat(tx.telecomSystem(CdwPractitionerTelecomSystem.PAGER))
+        .isEqualTo(ContactPointSystem.pager);
+    assertThat(tx.telecomSystem(CdwPractitionerTelecomSystem.PHONE))
+        .isEqualTo(ContactPointSystem.phone);
+  }
+
+  @Test
+  public void telecomUse() {
+    assertThat(tx.telecomUse(CdwPractitionerTelecomUse.HOME)).isEqualTo(ContactPointUse.home);
+    assertThat(tx.telecomUse(CdwPractitionerTelecomUse.MOBILE)).isEqualTo(ContactPointUse.mobile);
+    assertThat(tx.telecomUse(CdwPractitionerTelecomUse.OLD)).isEqualTo(ContactPointUse.old);
+    assertThat(tx.telecomUse(CdwPractitionerTelecomUse.TEMP)).isEqualTo(ContactPointUse.temp);
+    assertThat(tx.telecomUse(CdwPractitionerTelecomUse.WORK)).isEqualTo(ContactPointUse.work);
+  }
+
+  @Test
+  public void telecoms() {
     assertThat(tx.telecoms(null)).isNull();
     assertThat(tx.telecoms(new CdwTelecoms())).isNull();
     assertThat(tx.telecoms(cdw.telecoms())).isEqualTo(expected.telecoms());
@@ -144,16 +203,16 @@ public class PractitionerTransformerTest {
       return address;
     }
 
-    CdwAddresses addresses() {
-      CdwAddresses addresses = new CdwAddresses();
-      addresses.getAddress().add(address());
-      return addresses;
-    }
-
     CdwLines addressLines() {
       CdwLines lines = new CdwLines();
       lines.getLine().add("Address Line");
       return lines;
+    }
+
+    CdwAddresses addresses() {
+      CdwAddresses addresses = new CdwAddresses();
+      addresses.getAddress().add(address());
+      return addresses;
     }
 
     @SneakyThrows
@@ -211,12 +270,6 @@ public class PractitionerTransformerTest {
       return cdw;
     }
 
-    CdwPractitionerRoles practitionerRoles() {
-      CdwPractitionerRoles practitionerRoles = new CdwPractitionerRoles();
-      practitionerRoles.getPractitionerRole().add(practitionerRole());
-      return practitionerRoles;
-    }
-
     CdwPractitionerRole practitionerRole() {
       CdwPractitionerRole practitionerRole = new CdwPractitionerRole();
       practitionerRole.setHealthcareServices(healthcareServices());
@@ -224,6 +277,12 @@ public class PractitionerTransformerTest {
       practitionerRole.setManagingOrganization(managingOrganization());
       practitionerRole.setRole(role());
       return practitionerRole;
+    }
+
+    CdwPractitionerRoles practitionerRoles() {
+      CdwPractitionerRoles practitionerRoles = new CdwPractitionerRoles();
+      practitionerRoles.getPractitionerRole().add(practitionerRole());
+      return practitionerRoles;
     }
 
     CdwPractitionerRoleCoding role() {
@@ -240,13 +299,17 @@ public class PractitionerTransformerTest {
       return coding;
     }
 
-    CdwTelecoms telecoms() {
-      CdwTelecoms telecoms = new CdwTelecoms();
+    private CdwTelecom telecom() {
       CdwTelecom telecom = new CdwTelecom();
       telecom.setSystem(CdwPractitionerTelecomSystem.PHONE);
       telecom.setUse(CdwPractitionerTelecomUse.MOBILE);
       telecom.setValue("Hello Telecom Value");
-      telecoms.getTelecom().add(telecom);
+      return telecom;
+    }
+
+    CdwTelecoms telecoms() {
+      CdwTelecoms telecoms = new CdwTelecoms();
+      telecoms.getTelecom().add(telecom());
       return telecoms;
     }
   }
@@ -323,13 +386,16 @@ public class PractitionerTransformerTest {
           Coding.builder().code("doctor").system("Role System").display("Doctor").build());
     }
 
+    private ContactPoint telecom() {
+      return ContactPoint.builder()
+          .system(ContactPointSystem.phone)
+          .value("Hello Telecom Value")
+          .use(ContactPointUse.mobile)
+          .build();
+    }
+
     List<ContactPoint> telecoms() {
-      return singletonList(
-          ContactPoint.builder()
-              .system(ContactPointSystem.phone)
-              .value("Hello Telecom Value")
-              .use(ContactPointUse.mobile)
-              .build());
+      return singletonList(telecom());
     }
   }
 }

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerTransformerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerTransformerTest.java
@@ -1,0 +1,247 @@
+package gov.va.api.health.argonaut.service.controller.practitioner;
+
+import static java.util.Collections.singletonList;
+
+import gov.va.api.health.argonaut.api.datatypes.Address;
+import gov.va.api.health.argonaut.api.datatypes.CodeableConcept;
+import gov.va.api.health.argonaut.api.datatypes.Coding;
+import gov.va.api.health.argonaut.api.datatypes.ContactPoint;
+import gov.va.api.health.argonaut.api.datatypes.ContactPoint.ContactPointSystem;
+import gov.va.api.health.argonaut.api.datatypes.ContactPoint.ContactPointUse;
+import gov.va.api.health.argonaut.api.datatypes.HumanName;
+import gov.va.api.health.argonaut.api.datatypes.HumanName.NameUse;
+import gov.va.api.health.argonaut.api.elements.Reference;
+import gov.va.api.health.argonaut.api.resources.Practitioner;
+import gov.va.api.health.argonaut.api.resources.Practitioner.Gender;
+import gov.va.api.health.argonaut.api.resources.Practitioner.PractitionerRole;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwAddresses;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwAddresses.CdwAddress;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwAddresses.CdwAddress.CdwLines;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwName;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwPractitionerRoles;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwPractitionerRoles.CdwPractitionerRole;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwPractitionerRoles.CdwPractitionerRole.CdwHealthcareServices;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwPractitionerRoles.CdwPractitionerRole.CdwLocations;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwTelecoms;
+import gov.va.dvp.cdw.xsd.model.CdwPractitioner100Root.CdwPractitioners.CdwPractitioner.CdwTelecoms.CdwTelecom;
+import gov.va.dvp.cdw.xsd.model.CdwPractitionerGender;
+import gov.va.dvp.cdw.xsd.model.CdwPractitionerNameUse;
+import gov.va.dvp.cdw.xsd.model.CdwPractitionerRoleCoding;
+import gov.va.dvp.cdw.xsd.model.CdwPractitionerRoleCoding.CdwCoding;
+import gov.va.dvp.cdw.xsd.model.CdwPractitionerRoleCodingCode;
+import gov.va.dvp.cdw.xsd.model.CdwPractitionerRoleCodingDisplay;
+import gov.va.dvp.cdw.xsd.model.CdwPractitionerTelecomSystem;
+import gov.va.dvp.cdw.xsd.model.CdwPractitionerTelecomUse;
+import gov.va.dvp.cdw.xsd.model.CdwReference;
+import java.util.List;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+import lombok.SneakyThrows;
+
+public class PractitionerTransformerTest {
+
+  private PractitionerTransformer tx = new PractitionerTransformer();
+  private CdwSampleData cdw = new CdwSampleData();
+  private Expected expected = new Expected();
+
+  private static class CdwSampleData {
+
+    CdwAddress address() {
+      CdwAddress address = new CdwAddress();
+      address.setLines(addressLines());
+      address.setCity("Melbourne");
+      address.setState("FL");
+      address.setPostalCode("32904");
+      return address;
+    }
+
+    CdwAddresses addresses() {
+      CdwAddresses addresses = new CdwAddresses();
+      addresses.getAddress().add(address());
+      return addresses;
+    }
+
+    CdwLines addressLines() {
+      CdwLines lines = new CdwLines();
+      lines.getLine().add("Address Line");
+      return lines;
+    }
+
+    @SneakyThrows
+    private XMLGregorianCalendar birthDate(String s) {
+      return DatatypeFactory.newInstance().newXMLGregorianCalendar(s);
+    }
+
+    CdwReference cdwReference(String reference, String display) {
+      CdwReference cdwReference = new CdwReference();
+      cdwReference.setReference(reference);
+      cdwReference.setDisplay(display);
+      return cdwReference;
+    }
+
+    CdwHealthcareServices healthcareServices() {
+      CdwHealthcareServices healthcareServices = new CdwHealthcareServices();
+      CdwReference healthcareService =
+          cdwReference("HealthcareService/0", "*Unknown at this time*");
+      healthcareServices.getHealthcareService().add(healthcareService);
+      return healthcareServices;
+    }
+
+    CdwLocations locations() {
+      CdwLocations locations = new CdwLocations();
+      CdwReference location = cdwReference("Location/0", "*Unknown at this time*");
+      locations.getLocation().add(location);
+      return locations;
+    }
+
+    CdwReference managingOrganization() {
+      return cdwReference("Organization/0", "*Unknown at this time*");
+    }
+
+    CdwName name() {
+      CdwName name = new CdwName();
+      name.setFamily("Hello Family");
+      name.setGiven("Hello Given");
+      name.setPrefix("Hello Prefix");
+      name.setSuffix("Hello Suffix");
+      name.setText("Hello Text");
+      name.setUse(CdwPractitionerNameUse.OFFICIAL);
+      return name;
+    }
+
+    CdwPractitioner practitioner() {
+      CdwPractitioner cdw = new CdwPractitioner();
+      cdw.setCdwId("1234");
+      cdw.setActive(true);
+      cdw.setName(name());
+      cdw.setTelecoms(telecoms());
+      cdw.setAddresses(addresses());
+      cdw.setGender(CdwPractitionerGender.UNKNOWN);
+      cdw.setBirthDate(birthDate("1999-03-29T18:23:27Z"));
+      cdw.setPractitionerRoles(practitionerRoles());
+      return cdw;
+    }
+
+    CdwPractitionerRoles practitionerRoles() {
+      CdwPractitionerRoles practitionerRoles = new CdwPractitionerRoles();
+      practitionerRoles.getPractitionerRole().add(practitionerRole());
+      return practitionerRoles;
+    }
+
+    CdwPractitionerRole practitionerRole() {
+      CdwPractitionerRole practitionerRole = new CdwPractitionerRole();
+      practitionerRole.setHealthcareServices(healthcareServices());
+      practitionerRole.setLocations(locations());
+      practitionerRole.setManagingOrganization(managingOrganization());
+      practitionerRole.setRole(role());
+      return practitionerRole;
+    }
+
+    CdwPractitionerRoleCoding role() {
+      CdwPractitionerRoleCoding role = new CdwPractitionerRoleCoding();
+      role.setCoding(roleCoding());
+      return role;
+    }
+
+    CdwCoding roleCoding() {
+      CdwCoding coding = new CdwCoding();
+      coding.setCode(CdwPractitionerRoleCodingCode.DOCTOR);
+      coding.setDisplay(CdwPractitionerRoleCodingDisplay.DOCTOR);
+      coding.setSystem("Role System");
+      return coding;
+    }
+
+    CdwTelecoms telecoms() {
+      CdwTelecoms telecoms = new CdwTelecoms();
+      CdwTelecom telecom = new CdwTelecom();
+      telecom.setSystem(CdwPractitionerTelecomSystem.PHONE);
+      telecom.setUse(CdwPractitionerTelecomUse.MOBILE);
+      telecom.setValue("Hello Telecom Value");
+      telecoms.getTelecom().add(telecom);
+      return telecoms;
+    }
+  }
+
+  private static class Expected {
+
+    List<Address> addresses() {
+      return singletonList(
+          Address.builder()
+              .line(singletonList("Address Line"))
+              .city("Melbourne")
+              .state("FL")
+              .postalCode("32904")
+              .build());
+    }
+
+    List<Reference> healthcareServices() {
+      return singletonList(reference("HealthcareService/0", "*Unknown at this time*"));
+    }
+
+    List<Reference> locations() {
+      return singletonList(reference("Location/0", "*Unknown at this time*"));
+    }
+
+    Reference managingOrganization() {
+      return reference("Organization/0", "*Unknown at this time*");
+    }
+
+    HumanName name() {
+      return HumanName.builder()
+          .family(singletonList("Hello Family"))
+          .given(singletonList("Hello Given"))
+          .prefix(singletonList("Hello Prefix"))
+          .suffix(singletonList("Hello Suffix"))
+          .text("Hello Text")
+          .use(NameUse.official)
+          .build();
+    }
+
+    Practitioner practitioner() {
+      return Practitioner.builder()
+          .resourceType("Practitioner")
+          .id("1234")
+          .active(true)
+          .name(name())
+          .telecom(telecoms())
+          .address(addresses())
+          .gender(Gender.unknown)
+          .birthDate("1999-03-29T18:23:27Z")
+          .practitionerRole(practitionerRoles())
+          .build();
+    }
+
+    List<PractitionerRole> practitionerRoles() {
+      return singletonList(
+          PractitionerRole.builder()
+              .healthcareService(healthcareServices())
+              .location(locations())
+              .managingOrganization(managingOrganization())
+              .role(role())
+              .build());
+    }
+
+    private Reference reference(String reference, String display) {
+      return Reference.builder().reference(reference).display(display).build();
+    }
+
+    CodeableConcept role() {
+      return CodeableConcept.builder().coding(roleCoding()).build();
+    }
+
+    List<Coding> roleCoding() {
+      return singletonList(
+          Coding.builder().code("Doctor").system("Role System").display("Doctor").build());
+    }
+
+    List<ContactPoint> telecoms() {
+      return singletonList(
+          ContactPoint.builder()
+              .system(ContactPointSystem.phone)
+              .value("Hello Telecom Value")
+              .use(ContactPointUse.mobile)
+              .build());
+    }
+  }
+}

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerTransformerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerTransformerTest.java
@@ -48,13 +48,6 @@ public class PractitionerTransformerTest {
   private Expected expected = new Expected();
 
   @Test
-  public void telecom() {
-    assertThat(tx.telecoms(null)).isNull();
-    assertThat(tx.telecoms(new CdwTelecoms())).isNull();
-    assertThat(tx.telecoms(cdw.telecoms())).isSameAs(expected.telecoms());
-  }
-
-  @Test
   public void address() {
     assertThat(tx.addresses(null)).isNull();
     assertThat(tx.addresses(new CdwAddresses())).isNull();
@@ -99,6 +92,11 @@ public class PractitionerTransformerTest {
   }
 
   @Test
+  public void practitioner() {
+    assertThat(tx.apply(cdw.practitioner())).isEqualTo(expected.practitioner());
+  }
+
+  @Test
   public void practitionerRole() {
     assertThat(tx.practitionerRole(null)).isNull();
     assertThat(tx.practitionerRole(new CdwPractitionerRole())).isNull();
@@ -126,6 +124,13 @@ public class PractitionerTransformerTest {
     assertThat(tx.roleCoding(null)).isNull();
     assertThat(tx.roleCoding(new CdwCoding())).isNull();
     assertThat(tx.roleCoding(cdw.roleCoding())).isEqualTo(expected.roleCoding());
+  }
+
+  @Test
+  public void telecom() {
+    assertThat(tx.telecoms(null)).isNull();
+    assertThat(tx.telecoms(new CdwTelecoms())).isNull();
+    assertThat(tx.telecoms(cdw.telecoms())).isEqualTo(expected.telecoms());
   }
 
   private static class CdwSampleData {

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerTransformerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerTransformerTest.java
@@ -1,6 +1,7 @@
 package gov.va.api.health.argonaut.service.controller.practitioner;
 
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import gov.va.api.health.argonaut.api.datatypes.Address;
 import gov.va.api.health.argonaut.api.datatypes.CodeableConcept;
@@ -38,12 +39,94 @@ import java.util.List;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import lombok.SneakyThrows;
+import org.junit.Test;
 
 public class PractitionerTransformerTest {
 
   private PractitionerTransformer tx = new PractitionerTransformer();
   private CdwSampleData cdw = new CdwSampleData();
   private Expected expected = new Expected();
+
+  @Test
+  public void telecom() {
+    assertThat(tx.telecoms(null)).isNull();
+    assertThat(tx.telecoms(new CdwTelecoms())).isNull();
+    assertThat(tx.telecoms(cdw.telecoms())).isSameAs(expected.telecoms());
+  }
+
+  @Test
+  public void address() {
+    assertThat(tx.addresses(null)).isNull();
+    assertThat(tx.addresses(new CdwAddresses())).isNull();
+    assertThat(tx.addresses(cdw.addresses())).isEqualTo(expected.addresses());
+  }
+
+  @Test
+  public void addressLines() {
+    assertThat(tx.addressLines(null)).isNull();
+    assertThat(tx.addressLines(new CdwLines())).isNull();
+    assertThat(tx.addressLines(cdw.addressLines())).isEqualTo(expected.addresses().get(0).line());
+  }
+
+  @Test
+  public void healthcareServices() {
+    assertThat(tx.healthcareService(null)).isNull();
+    assertThat(tx.healthcareService(new CdwHealthcareServices())).isNull();
+    assertThat(tx.healthcareService(cdw.healthcareServices()))
+        .isEqualTo(expected.healthcareServices());
+  }
+
+  @Test
+  public void locations() {
+    assertThat(tx.locations(null)).isNull();
+    assertThat(tx.locations(new CdwLocations())).isNull();
+    assertThat(tx.locations(cdw.locations())).isEqualTo(expected.locations());
+  }
+
+  @Test
+  public void managingOrganization() {
+    assertThat(tx.managingOrganization(null)).isNull();
+    assertThat(tx.managingOrganization(new CdwReference())).isNull();
+    assertThat(tx.managingOrganization(cdw.managingOrganization()))
+        .isEqualTo(expected.managingOrganization());
+  }
+
+  @Test
+  public void name() {
+    assertThat(tx.name(null)).isNull();
+    assertThat(tx.name(new CdwName())).isNull();
+    assertThat(tx.name(cdw.name())).isEqualTo(expected.name());
+  }
+
+  @Test
+  public void practitionerRole() {
+    assertThat(tx.practitionerRole(null)).isNull();
+    assertThat(tx.practitionerRole(new CdwPractitionerRole())).isNull();
+    assertThat(tx.practitionerRole(cdw.practitionerRole()))
+        .isEqualTo(expected.practitionerRoles().get(0));
+  }
+
+  @Test
+  public void practitionerRoles() {
+    assertThat(tx.practitionerRoles(null)).isNull();
+    assertThat(tx.practitionerRoles(new CdwPractitionerRoles())).isNull();
+    assertThat(tx.practitionerRoles(cdw.practitionerRoles()))
+        .isEqualTo(expected.practitionerRoles());
+  }
+
+  @Test
+  public void role() {
+    assertThat(tx.role(null)).isNull();
+    assertThat(tx.role(new CdwPractitionerRoleCoding())).isNull();
+    assertThat(tx.role(cdw.role())).isEqualTo(expected.role());
+  }
+
+  @Test
+  public void roleCoding() {
+    assertThat(tx.roleCoding(null)).isNull();
+    assertThat(tx.roleCoding(new CdwCoding())).isNull();
+    assertThat(tx.roleCoding(cdw.roleCoding())).isEqualTo(expected.roleCoding());
+  }
 
   private static class CdwSampleData {
 
@@ -232,7 +315,7 @@ public class PractitionerTransformerTest {
 
     List<Coding> roleCoding() {
       return singletonList(
-          Coding.builder().code("Doctor").system("Role System").display("Doctor").build());
+          Coding.builder().code("doctor").system("Role System").display("Doctor").build());
     }
 
     List<ContactPoint> telecoms() {

--- a/argonaut/src/test/resources/cdw/old-practitioner-1.00.json
+++ b/argonaut/src/test/resources/cdw/old-practitioner-1.00.json
@@ -1,0 +1,39 @@
+{
+  "resourceType": "Practitioner",
+  "id": "cb75cf5c-0405-5dae-a37a-42f750c40135",
+  "active": false,
+  "name": {
+    "use": "usual",
+    "text": "JONES,PRACTITIONER A",
+    "family": [
+      "JONES"
+    ],
+    "given": [
+      "PRACTITIONER A"
+    ]
+  },
+  "gender": "female",
+  "birthDate": "1988-05-16",
+  "practitionerRole": [
+    {
+      "managingOrganization": {
+        "reference": "https://www.freedomstream.io/CDCArgonaut/api/Organization/7188c8bc-c284-5f3f-9c51-93f5a78d5e41",
+        "display": "VA HEARTLAND - WEST, VISN 15"
+      },
+      "role": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/practitioner-role",
+            "code": "nurse",
+            "display": "Nurse"
+          }
+        ]
+      },
+      "healthcareService": [
+        {
+          "display": "EKH NURSING SERVICE"
+        }
+      ]
+    }
+  ]
+}

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/IdRegistrar.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/IdRegistrar.java
@@ -63,6 +63,7 @@ class IdRegistrar {
     ResourceIdentity medicationStatement = id("MEDICATION_STATEMENT", cdwIds.medicationStatement());
     ResourceIdentity observation = id("OBSERVATION", cdwIds.observation());
     ResourceIdentity patient = id("PATIENT", cdwIds.patient());
+    ResourceIdentity practitioner = id("PRACTITIONER", cdwIds.practitioner());
     ResourceIdentity procedure = id("PROCEDURE", cdwIds.procedure());
 
     List<ResourceIdentity> identities =
@@ -76,6 +77,7 @@ class IdRegistrar {
             medication,
             medicationStatement,
             observation,
+            practitioner,
             procedure);
     log.info("Registering {}", identities);
     List<Registration> registrations =
@@ -97,6 +99,7 @@ class IdRegistrar {
             .medicationStatement(findUuid(registrations, medicationStatement))
             .observation(findUuid(registrations, observation))
             .patient(findUuid(registrations, patient))
+            .practitioner(findUuid(registrations, practitioner))
             .procedure(findUuid(registrations, procedure))
             .build();
     log.info("Using {}", publicIds);

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/SystemDefinitions.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/SystemDefinitions.java
@@ -24,7 +24,6 @@ public class SystemDefinitions {
                   .condition("1400007575530:P")
                   .diagnosticReport("1000000031384:L")
                   .encounter("1200753214085")
-                  .patient("185601V825290")
                   .diagnosticReports(
                       DiagnosticReports.builder()
                           .loinc1("10000-8")
@@ -52,6 +51,8 @@ public class SystemDefinitions {
                           .name("VETERAN,JOHN")
                           .family("VETERAN")
                           .build())
+                  .patient("185601V825290")
+                  .practitioner("10092125")
                   .procedure("1400000140034")
                   .procedures(
                       Procedures.builder()

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/TestIds.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/TestIds.java
@@ -19,6 +19,7 @@ public class TestIds {
   @NonNull String medicationStatement;
   @NonNull String observation;
   @NonNull String patient;
+  @NonNull String practitioner;
   @NonNull String procedure;
   @NonNull String unknown;
 

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/ArgonautReadAndSearchIT.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/ArgonautReadAndSearchIT.java
@@ -10,6 +10,7 @@ import gov.va.api.health.argonaut.api.resources.MedicationStatement;
 import gov.va.api.health.argonaut.api.resources.Observation;
 import gov.va.api.health.argonaut.api.resources.OperationOutcome;
 import gov.va.api.health.argonaut.api.resources.Patient;
+import gov.va.api.health.argonaut.api.resources.Practitioner;
 import gov.va.api.health.argonaut.api.resources.Procedure;
 import java.util.Arrays;
 import java.util.List;
@@ -265,6 +266,16 @@ public class ArgonautReadAndSearchIT {
             "/api/Patient?name={name}&gender={gender}",
             ids.pii().name(),
             ids.pii().gender()),
+        // Practitioner
+        expect(200, Practitioner.class, "/api/Practitioner/{id}", ids.practitioner()),
+        expect(404, OperationOutcome.class, "/api/Practitioner/{id}", ids.unknown()),
+        expect(200, Practitioner.Bundle.class, "/api/Practitioner?_id={id}", ids.practitioner()),
+        expect(
+            200,
+            Practitioner.Bundle.class,
+            "/api/Practitioner?identifier={id}",
+            ids.practitioner()),
+        expect(404, OperationOutcome.class, "/api/Practitioner?_id={id}", ids.unknown()),
         // Procedure
         expect(200, Procedure.class, "/api/Procedure/{id}", ids.procedure()),
         expect(404, OperationOutcome.class, "/api/Procedure/{id}", ids.unknown()),

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/ArgonautValidateIT.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/ArgonautValidateIT.java
@@ -11,6 +11,7 @@ import gov.va.api.health.argonaut.api.resources.MedicationStatement;
 import gov.va.api.health.argonaut.api.resources.Observation;
 import gov.va.api.health.argonaut.api.resources.OperationOutcome;
 import gov.va.api.health.argonaut.api.resources.Patient;
+import gov.va.api.health.argonaut.api.resources.Practitioner;
 import gov.va.api.health.argonaut.api.resources.Procedure;
 import java.util.Arrays;
 import java.util.List;
@@ -49,6 +50,7 @@ public class ArgonautValidateIT {
             "MedicationStatement", ids.medicationStatement(), MedicationStatement.Bundle.class),
         validate("Observation", ids.observation(), Observation.Bundle.class),
         validate("Patient", ids.patient(), Patient.Bundle.class),
+        validate("Practitioner", ids.practitioner(), Practitioner.Bundle.class),
         validate("Procedure", ids.procedure(), Procedure.Bundle.class));
   }
 


### PR DESCRIPTION
Add Practitioner support for read, search by _id and identifier, validate, and add the appropriate sentinel tests.
Related story: https://vasdvp.atlassian.net/browse/API-430