### PR TITLE
Task/api 587 reference links

### DIFF
--- a/argonaut-api/checkstyle-suppressions.xml
+++ b/argonaut-api/checkstyle-suppressions.xml
@@ -3,9 +3,11 @@
   "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
   <!--
-    Immunization report _status and _reported are data absent reason fields.
-    Procedure _status is a data absent reason field.
+    The following resources have certain fields that are reported
+    as data absent reason extensions that is required to have a _
+    prefix by the Argonaut specification.
   -->
   <suppress checks="MemberName" files=".*(/|\\)Immunization.java" message="Member name '(_status|_reported)'"/>
   <suppress checks="MemberName" files=".*(/|\\)Procedure.java" message="Member name '(_status)'"/>
+  <suppress checks="MemberName" files=".*(/|\\)MedicationOrder.java" message="Member name '(_prescriber)'"/>
 </suppressions>

--- a/argonaut-api/src/main/java/gov/va/api/health/argonaut/api/resources/MedicationOrder.java
+++ b/argonaut-api/src/main/java/gov/va/api/health/argonaut/api/resources/MedicationOrder.java
@@ -24,6 +24,7 @@ import gov.va.api.health.argonaut.api.elements.Meta;
 import gov.va.api.health.argonaut.api.elements.Narrative;
 import gov.va.api.health.argonaut.api.elements.Reference;
 import gov.va.api.health.argonaut.api.validation.ExactlyOneOf;
+import gov.va.api.health.argonaut.api.validation.ExactlyOneOfs;
 import gov.va.api.health.argonaut.api.validation.ZeroOrOneOf;
 import gov.va.api.health.argonaut.api.validation.ZeroOrOneOfs;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -53,10 +54,13 @@ import lombok.NoArgsConstructor;
   fields = {"reasonCodeableConcept", "reasonReference"},
   message = "Only one reason field may be specified"
 )
-@ExactlyOneOf(
-  fields = {"medicationCodeableConcept", "medicationReference"},
-  message = "Exactly one medication field must be specified"
-)
+@ExactlyOneOfs({
+  @ExactlyOneOf(
+    fields = {"medicationCodeableConcept", "medicationReference"},
+    message = "Exactly one medication field must be specified"
+  ),
+  @ExactlyOneOf(fields = {"prescriber", "_prescriber"}),
+})
 public class MedicationOrder implements Resource {
   @NotBlank String resourceType;
 
@@ -89,6 +93,7 @@ public class MedicationOrder implements Resource {
   @Valid CodeableConcept reasonEnded;
   @Valid @NotNull Reference patient;
   @Valid @NotNull Reference prescriber;
+  @Valid Extension _prescriber;
   @Valid Reference encounter;
   @Valid CodeableConcept reasonCodeableConcept;
   @Valid Reference reasonReference;

--- a/argonaut-api/src/main/java/gov/va/api/health/argonaut/api/resources/MedicationOrder.java
+++ b/argonaut-api/src/main/java/gov/va/api/health/argonaut/api/resources/MedicationOrder.java
@@ -92,7 +92,7 @@ public class MedicationOrder implements Resource {
 
   @Valid CodeableConcept reasonEnded;
   @Valid @NotNull Reference patient;
-  @Valid @NotNull Reference prescriber;
+  @Valid Reference prescriber;
   @Valid Extension _prescriber;
   @Valid Reference encounter;
   @Valid CodeableConcept reasonCodeableConcept;

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/IdMeOauthRobot.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/IdMeOauthRobot.java
@@ -45,14 +45,18 @@ public class IdMeOauthRobot {
     }
     WebDriver driver = new ChromeDriver(chromeOptions);
 
+    log.info("Loading {}", config.authorization().asUrl());
     driver.get(config.authorization().asUrl());
+    log.info("Using Id.me");
     driver.findElement(By.className("idme-signin")).click();
+    log.info("Entering credentials");
     WebElement userEmail = driver.findElement(By.id("user_email"));
     userEmail.sendKeys(config.user().id());
     WebElement userPassword = driver.findElement(By.id("user_password"));
     userPassword.sendKeys(config.user().password());
     driver.findElement(By.className("btn-primary")).click();
     // Continue passed authentication code send form
+    log.info("Clicking to two factor authorization sham");
     driver.findElement(By.className("btn-primary")).click();
     // Continue passed entering the authentication code
     driver.findElement(By.className("btn-primary")).click();
@@ -76,6 +80,7 @@ public class IdMeOauthRobot {
   }
 
   private TokenExchange exchangeForCodeForToken() {
+    log.info("Exchaning authorization code for token");
     return RestAssured.given()
         .contentType(ContentType.URLENC.withCharset("UTF-8"))
         .formParam("client_id", config.authorization().clientId())

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/Crawler.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/Crawler.java
@@ -1,8 +1,10 @@
 package gov.va.health.api.sentinel.crawler;
 
 import io.restassured.RestAssured;
+import io.restassured.response.Response;
 import java.util.function.Supplier;
 import lombok.Builder;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 /** The Crawler will recursive request resources from an Argonaut server. I */
@@ -15,21 +17,42 @@ public class Crawler {
 
   /** Crawler iterates through queue performing all queries. */
   public void crawl() {
+    int count = 0; // TODO remove me
     while (requestQueue.hasNext()) {
+      count++;
       String url = requestQueue.next();
+      try {
+        process(url);
+      } catch (Exception e) {
+        log.error("Failed to process {}", url, e);
+        // TODO return result
+      }
+    }
+    log.info("Made {} requests", count); // TODO remove me
+  }
 
-      Class<?> type = new UrlToResourceConverter().apply(url);
-
-      log.info("Requesting {} as {}", url, type.getName());
-
-      RestAssured.given()
-          .header("Authorization", "Bearer " + authenticationToken.get())
-          .contentType("application/fhir+json")
-          // TODO .header("jargonaut", USE_JARGONAUT)
-          .get(url)
-          .then()
-          .log()
-          .all();
+  @SneakyThrows
+  private void process(String url) {
+    // TODO return result
+    Class<?> type = new UrlToResourceConverter().apply(url);
+    log.info("Requesting {} as {}", url, type.getName());
+    Response response =
+        RestAssured.given()
+            .header("Authorization", "Bearer " + authenticationToken.get())
+            .contentType("application/fhir+json")
+            // TODO .header("jargonaut", USE_JARGONAUT)
+            .get(url)
+            .andReturn();
+    if (response.getStatusCode() == 200) {
+      ReferenceInterceptor interceptor = new ReferenceInterceptor();
+      Object payload = interceptor.mapper().readValue(response.asByteArray(), type);
+      log.info(
+          "Found {} references in {}",
+          interceptor.references().size(),
+          payload.getClass().getName());
+      interceptor.references().forEach(u -> requestQueue.add(u));
+    } else {
+      // TODO return sad result
     }
   }
 }

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/Crawler.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/Crawler.java
@@ -1,11 +1,20 @@
 package gov.va.health.api.sentinel.crawler;
 
+import static java.util.stream.Collectors.joining;
+
+import gov.va.health.api.sentinel.crawler.Result.Outcome;
+import gov.va.health.api.sentinel.crawler.Result.ResultBuilder;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import java.time.Instant;
+import java.util.Set;
 import java.util.function.Supplier;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
 import lombok.Builder;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 /** The Crawler will recursive request resources from an Argonaut server. I */
 @Builder
@@ -13,27 +22,43 @@ import lombok.extern.slf4j.Slf4j;
 public class Crawler {
 
   private final RequestQueue requestQueue;
+  private final ResultCollector results;
   private final Supplier<String> authenticationToken;
+
+  private String asAdditionalInfo(Exception e) {
+    StringBuilder info = new StringBuilder();
+    info.append("Exception: ")
+        .append(e.getClass().getName())
+        .append("\nMessage: ")
+        .append(e.getMessage())
+        .append("\n----\n")
+        .append(ExceptionUtils.getStackTrace(e));
+    return info.toString();
+  }
+
+  private String asAdditionalInfo(ConstraintViolation<?> v) {
+    return v.getPropertyPath() + ": " + v.getMessage() + ", got: " + v.getInvalidValue();
+  }
 
   /** Crawler iterates through queue performing all queries. */
   public void crawl() {
-    int count = 0; // TODO remove me
+    results.init();
     while (requestQueue.hasNext()) {
-      count++;
       String url = requestQueue.next();
+      ResultBuilder resultBuilder = Result.builder().timestamp(Instant.now()).query(url);
       try {
-        process(url);
+        process(url, resultBuilder);
       } catch (Exception e) {
         log.error("Failed to process {}", url, e);
-        // TODO return result
+        resultBuilder.outcome(Outcome.REQUEST_FAILED).additionalInfo(asAdditionalInfo(e));
       }
+      results.add(resultBuilder.build());
     }
-    log.info("Made {} requests", count); // TODO remove me
+    results.done();
   }
 
   @SneakyThrows
-  private void process(String url) {
-    // TODO return result
+  private void process(String url, ResultBuilder resultBuilder) {
     Class<?> type = new UrlToResourceConverter().apply(url);
     log.info("Requesting {} as {}", url, type.getName());
     Response response =
@@ -43,6 +68,8 @@ public class Crawler {
             // TODO .header("jargonaut", USE_JARGONAUT)
             .get(url)
             .andReturn();
+    resultBuilder.httpStatus(response.getStatusCode()).body(response.getBody().asString());
+
     if (response.getStatusCode() == 200) {
       ReferenceInterceptor interceptor = new ReferenceInterceptor();
       Object payload = interceptor.mapper().readValue(response.asByteArray(), type);
@@ -51,8 +78,18 @@ public class Crawler {
           interceptor.references().size(),
           payload.getClass().getName());
       interceptor.references().forEach(u -> requestQueue.add(u));
+
+      Set<ConstraintViolation<Object>> violations =
+          Validation.buildDefaultValidatorFactory().getValidator().validate(payload);
+      if (violations.isEmpty()) {
+        resultBuilder.outcome(Outcome.OK);
+      } else {
+        resultBuilder
+            .outcome(Outcome.INVALID_PAYLOAD)
+            .additionalInfo(violations.stream().map(this::asAdditionalInfo).collect(joining("\n")));
+      }
     } else {
-      // TODO return sad result
+      resultBuilder.outcome(Outcome.INVALID_STATUS);
     }
   }
 }

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/ReferenceInterceptor.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/ReferenceInterceptor.java
@@ -1,0 +1,98 @@
+package gov.va.health.api.sentinel.crawler;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.BeanDeserializer;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import gov.va.api.health.argonaut.api.elements.Reference;
+import gov.va.api.health.autoconfig.configuration.JacksonConfig;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * This class provides a customized Jackson mapper that will intercept and record URLs of all
+ * reference objects.
+ *
+ * <ul>
+ *   <li>Order of references in not guaranteed.
+ *   <li>This class is NOT thread safe.
+ *   <li>Instances of this class or the mappers created by it may be used more once. References will
+ *       be accumulated.
+ * </ul>
+ *
+ * <p>Order is not guaranteed.
+ *
+ * <pre>
+ * ReferenceInterceptor interceptor = new ReferenceInterceptor();
+ * Thing t = interceptor.mapper().readValue(json,Thing.class);
+ * interceptor.references().forEach(url -> coolLink(url));
+ * </pre>
+ */
+@Slf4j
+class ReferenceInterceptor {
+  @Getter private final Set<String> references = new HashSet<>();
+
+  /**
+   * Return a new mapper that can be used to collect references. Call `references()` after this
+   * method.
+   */
+  ObjectMapper mapper() {
+    ObjectMapper mapper = JacksonConfig.createMapper();
+    SimpleModule cheat = new SimpleModule();
+    cheat.setDeserializerModifier(new ReferenceDeserializerModifier());
+    mapper.registerModule(cheat);
+    return mapper;
+  }
+
+  /**
+   * This modifier will wrap the normal deserializer. Values returned will be inspected. References
+   * with a valid URL specified will be recorded.
+   */
+  private class ReferenceDeserializer extends BeanDeserializer {
+
+    ReferenceDeserializer(BeanDeserializer deserializer) {
+      super(deserializer);
+    }
+
+    @Override
+    public Object deserialize(JsonParser p, DeserializationContext ctxt)
+        throws IOException, JsonProcessingException {
+      Object value = super.deserialize(p, ctxt);
+      if (value instanceof Reference) {
+        Reference reference = (Reference) value;
+        if (StringUtils.isNotBlank(reference.reference())) {
+          if (references.add(reference.reference())) {
+            log.info("Found reference to '{}' ({})", reference.display(), reference.reference());
+          }
+        }
+      }
+      return value;
+    }
+  }
+
+  /**
+   * This janky modifier is used to intercept the deserializer configuration for the Reference
+   * class. It will install our custom deserializer instead.
+   */
+  private class ReferenceDeserializerModifier extends BeanDeserializerModifier {
+    @Override
+    public JsonDeserializer<?> modifyDeserializer(
+        DeserializationConfig config, BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
+      if (Reference.class.isAssignableFrom(beanDesc.getBeanClass())
+          && deserializer instanceof BeanDeserializer) {
+        return new ReferenceDeserializer((BeanDeserializer) deserializer);
+      }
+      return deserializer;
+    }
+  }
+}

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/Result.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/Result.java
@@ -3,13 +3,13 @@ package gov.va.health.api.sentinel.crawler;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
 /** The result of the query. */
 @AllArgsConstructor
 @Builder
-@Data
+@Value
 public class Result {
 
   @NonNull Instant timestamp;

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/LabTest.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/LabTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import gov.va.health.api.sentinel.categories.Lab;
 import gov.va.health.api.sentinel.crawler.ConcurrentRequestQueue;
 import gov.va.health.api.sentinel.crawler.Crawler;
+import gov.va.health.api.sentinel.crawler.FileResultsCollector;
 import gov.va.health.api.sentinel.crawler.RequestQueue;
 import gov.va.health.api.sentinel.crawler.ResourceDiscovery;
 import org.junit.Test;
@@ -27,6 +28,7 @@ public class LabTest {
     Crawler crawler =
         Crawler.builder()
             .requestQueue(q)
+            .results(new FileResultsCollector())
             .authenticationToken(() -> robots.user1().token().accessToken())
             .build();
     crawler.crawl();

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/crawler/ReferenceInterceptorTest.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/crawler/ReferenceInterceptorTest.java
@@ -1,0 +1,79 @@
+package gov.va.health.api.sentinel.crawler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import gov.va.api.health.argonaut.api.elements.Reference;
+import gov.va.api.health.autoconfig.configuration.JacksonConfig;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Singular;
+import lombok.SneakyThrows;
+import org.junit.Test;
+
+public class ReferenceInterceptorTest {
+
+  private Reference reference(String path) {
+    return Reference.builder().display("display-value").reference(path).id("id-value").build();
+  }
+
+  @Test
+  @SneakyThrows
+  public void referencesFound() {
+    FugaziReferencemajig before =
+        FugaziReferencemajig.builder()
+            .whocares("noone")
+            .me(true)
+            .ref(reference("https://example.com/api/AllergyIntolerance/1234"))
+            .thing(reference(null))
+            .thing(reference("https://example.com/api/Organization?patient=123"))
+            .thing(reference("https://example.com/api/Organization/1234"))
+            .thing(reference("https://example.com/api/Organization/1234"))
+            .inner(
+                FugaziReferencemajig.builder()
+                    .ref(
+                        Reference.builder()
+                            .reference(
+                                "https://example.com/api/Appointment/615f31df-f0c7-5100-ac42-7fb952c630d0")
+                            .build())
+                    .build())
+            .build();
+    ReferenceInterceptor interceptor = new ReferenceInterceptor();
+    FugaziReferencemajig after =
+        interceptor
+            .mapper()
+            .readValue(
+                JacksonConfig.createMapper().writeValueAsString(before),
+                FugaziReferencemajig.class);
+
+    assertThat(after).isEqualTo(before);
+    assertThat(interceptor.references())
+        .containsExactlyInAnyOrder(
+            "https://example.com/api/AllergyIntolerance/1234",
+            "https://example.com/api/Organization?patient=123",
+            "https://example.com/api/Organization/1234",
+            "https://example.com/api/Appointment/615f31df-f0c7-5100-ac42-7fb952c630d0");
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(
+    fieldVisibility = JsonAutoDetect.Visibility.ANY,
+    isGetterVisibility = Visibility.NONE
+  )
+  public static class FugaziReferencemajig {
+    Reference ref;
+    Reference nope;
+    @Singular List<Reference> things;
+    FugaziReferencemajig inner;
+    String whocares;
+    Boolean me;
+  }
+}


### PR DESCRIPTION
Crawler will now  …
- validate status and payload
- produce Result objects and add then to the result collector

MedicationOrder no longer requires a prescriber but will allow _prescriber instead