### PR TITLE
Bug/api 562 observation omit system when no code available

### DIFF
--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/observation/ObservationTransformer.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/observation/ObservationTransformer.java
@@ -38,6 +38,7 @@ import gov.va.dvp.cdw.xsd.model.CdwReference;
 import java.math.BigDecimal;
 import java.util.List;
 import javax.validation.constraints.NotNull;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -289,14 +290,8 @@ public class ObservationTransformer implements ObservationController.Transformer
             maybeCdw.getSystem(), maybeCdw.getCode(), maybeCdw.getUnit(), maybeCdw.getValue())) {
       return null;
     }
-    if (maybeCdw.getCode() == null) {
-      return SimpleQuantity.builder()
-          .value(ifPresent(maybeCdw.getValue(), BigDecimal::doubleValue))
-          .unit(maybeCdw.getUnit())
-          .build();
-    }
     return SimpleQuantity.builder()
-        .system(maybeCdw.getSystem())
+        .system(StringUtils.isBlank(maybeCdw.getCode())?null:maybeCdw.getSystem())
         .value(ifPresent(maybeCdw.getValue(), BigDecimal::doubleValue))
         .unit(maybeCdw.getUnit())
         .code(maybeCdw.getCode())
@@ -354,21 +349,11 @@ public class ObservationTransformer implements ObservationController.Transformer
             maybeCdw.getValue())) {
       return null;
     }
-    if (maybeCdw.getCode() == null) {
-      return ifPresent(
-          maybeCdw,
-          cdw ->
-              Quantity.builder()
-                  .value(cdw.getValue().doubleValue())
-                  .comparator(cdw.getComparator())
-                  .unit(cdw.getUnit())
-                  .build());
-    }
     return ifPresent(
         maybeCdw,
         cdw ->
             Quantity.builder()
-                .system(cdw.getSystem())
+                .system(StringUtils.isBlank(cdw.getCode())?null:cdw.getSystem())
                 .value(cdw.getValue().doubleValue())
                 .comparator(cdw.getComparator())
                 .code(cdw.getCode())

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/observation/ObservationTransformer.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/observation/ObservationTransformer.java
@@ -289,6 +289,12 @@ public class ObservationTransformer implements ObservationController.Transformer
             maybeCdw.getSystem(), maybeCdw.getCode(), maybeCdw.getUnit(), maybeCdw.getValue())) {
       return null;
     }
+    if (maybeCdw.getCode() == null) {
+      return SimpleQuantity.builder()
+          .value(ifPresent(maybeCdw.getValue(), BigDecimal::doubleValue))
+          .unit(maybeCdw.getUnit())
+          .build();
+    }
     return SimpleQuantity.builder()
         .system(maybeCdw.getSystem())
         .value(ifPresent(maybeCdw.getValue(), BigDecimal::doubleValue))
@@ -347,6 +353,16 @@ public class ObservationTransformer implements ObservationController.Transformer
             maybeCdw.getUnit(),
             maybeCdw.getValue())) {
       return null;
+    }
+    if (maybeCdw.getCode() == null) {
+      return ifPresent(
+          maybeCdw,
+          cdw ->
+              Quantity.builder()
+                  .value(cdw.getValue().doubleValue())
+                  .comparator(cdw.getComparator())
+                  .unit(cdw.getUnit())
+                  .build());
     }
     return ifPresent(
         maybeCdw,

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/observation/ObservationTransformerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/observation/ObservationTransformerTest.java
@@ -185,7 +185,9 @@ public class ObservationTransformerTest {
     assertThat(tx.referenceRangeQuantity(null)).isNull();
     assertThat(tx.referenceRangeQuantity(new CdwObservationRefRangeQuantity())).isNull();
     assertThat(tx.referenceRangeQuantity(cdw.referenceRangeQuantity(1)))
-        .isEqualTo(expected.simpleQuantity(1));
+        .isEqualTo(expected.referenceRangeQuantity(1));
+    assertThat(tx.referenceRangeQuantity(cdw.emptyReferenceRangeQuantity(1)))
+        .isEqualTo(expected.emptyCodeReferenceRangeQuantity(1));
   }
 
   @Test
@@ -228,6 +230,8 @@ public class ObservationTransformerTest {
     assertThat(tx.valueQuantity(null)).isNull();
     assertThat(tx.valueQuantity(new CdwValueQuantity())).isNull();
     assertThat(tx.valueQuantity(cdw.valueQuantity())).isEqualTo(expected.valueQuantity());
+    assertThat(tx.valueQuantity(cdw.emptyCodeValueQuantity()))
+        .isEqualTo(expected.emptyCodeValueQuantity());
   }
 
   @NoArgsConstructor(staticName = "get", access = AccessLevel.PUBLIC)
@@ -402,6 +406,14 @@ public class ObservationTransformerTest {
       return cdw;
     }
 
+    private CdwObservationRefRangeQuantity emptyReferenceRangeQuantity(long value) {
+      CdwObservationRefRangeQuantity cdw = new CdwObservationRefRangeQuantity();
+      cdw.setUnit("k/cmm");
+      cdw.setSystem("http://unitsofmeasure.org");
+      cdw.setValue(BigDecimal.valueOf(value));
+      return cdw;
+    }
+
     private CdwReferenceRanges referenceRanges() {
       CdwReferenceRanges cdw = new CdwReferenceRanges();
       cdw.getReferenceRange().add(referenceRange());
@@ -427,6 +439,15 @@ public class ObservationTransformerTest {
     private CdwValueQuantity valueQuantity() {
       CdwValueQuantity cdw = new CdwValueQuantity();
       cdw.setCode("/min");
+      cdw.setComparator("<");
+      cdw.setSystem("http://unitsofmeasure.org");
+      cdw.setUnit("/min");
+      cdw.setValue(BigDecimal.valueOf(74));
+      return cdw;
+    }
+
+    private CdwValueQuantity emptyCodeValueQuantity() {
+      CdwValueQuantity cdw = new CdwValueQuantity();
       cdw.setComparator("<");
       cdw.setSystem("http://unitsofmeasure.org");
       cdw.setUnit("/min");
@@ -550,8 +571,8 @@ public class ObservationTransformerTest {
 
     private ObservationReferenceRange referenceRange() {
       return ObservationReferenceRange.builder()
-          .high(simpleQuantity(10))
-          .low(simpleQuantity(1))
+          .high(referenceRangeQuantity(10))
+          .low(referenceRangeQuantity(1))
           .build();
     }
 
@@ -559,13 +580,17 @@ public class ObservationTransformerTest {
       return singletonList(referenceRange());
     }
 
-    private SimpleQuantity simpleQuantity(int value) {
+    private SimpleQuantity referenceRangeQuantity(int value) {
       return SimpleQuantity.builder()
           .system("http://unitsofmeasure.org")
           .code("k/cmm")
           .unit("k/cmm")
           .value((double) value)
           .build();
+    }
+
+    private SimpleQuantity emptyCodeReferenceRangeQuantity(int value) {
+      return SimpleQuantity.builder().unit("k/cmm").value((double) value).build();
     }
 
     CodeableConcept valueCodeableConcept() {
@@ -581,6 +606,10 @@ public class ObservationTransformerTest {
           .unit("/min")
           .value(74D)
           .build();
+    }
+
+    Quantity emptyCodeValueQuantity() {
+      return Quantity.builder().comparator("<").unit("/min").value(74D).build();
     }
   }
 }


### PR DESCRIPTION
Nulls the system field in observation.valueQuantity.high, observation.valueQuantity.low, observation.referenceRange.high, and observation.referenceRange.low when no code is present.
Relevant bug: https://vasdvp.atlassian.net/browse/API-562