### PR TITLE
Task/api 593 Create DAR for Diagnostic Report Performer

### DIFF
--- a/argonaut-api/checkstyle-suppressions.xml
+++ b/argonaut-api/checkstyle-suppressions.xml
@@ -8,6 +8,7 @@
     prefix by the Argonaut specification.
   -->
   <suppress checks="MemberName" files=".*(/|\\)Immunization.java" message="Member name '(_status|_reported)'"/>
-  <suppress checks="MemberName" files=".*(/|\\)Procedure.java" message="Member name '(_status)'"/>
+  <suppress checks="MemberName" files=".*(/|\\)DiagnosticReport.java" message="Member name '(_performer)'"/>
   <suppress checks="MemberName" files=".*(/|\\)MedicationOrder.java" message="Member name '(_prescriber)'"/>
+  <suppress checks="MemberName" files=".*(/|\\)Procedure.java" message="Member name '(_status)'"/>
 </suppressions>

--- a/argonaut-api/src/main/java/gov/va/api/health/argonaut/api/resources/DiagnosticReport.java
+++ b/argonaut-api/src/main/java/gov/va/api/health/argonaut/api/resources/DiagnosticReport.java
@@ -19,6 +19,7 @@ import gov.va.api.health.argonaut.api.elements.Extension;
 import gov.va.api.health.argonaut.api.elements.Meta;
 import gov.va.api.health.argonaut.api.elements.Narrative;
 import gov.va.api.health.argonaut.api.elements.Reference;
+import gov.va.api.health.argonaut.api.validation.ExactlyOneOf;
 import gov.va.api.health.argonaut.api.validation.ZeroOrOneOf;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -45,6 +46,7 @@ import org.apache.commons.lang3.StringUtils;
   description =
       "http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-diagnosticreport.html"
 )
+@ExactlyOneOf(fields = {"performer", "_performer"})
 @ZeroOrOneOf(
   fields = {"effectiveDateTime", "effectivePeriod"},
   message = "Only one effective value may be specified"
@@ -86,7 +88,8 @@ public class DiagnosticReport implements Resource {
   @NotBlank
   String issued;
 
-  @NotNull @Valid Reference performer;
+  @Valid Reference performer;
+  @Valid Extension _performer;
 
   @Valid List<Reference> request;
   @Valid List<Reference> specimen;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/diagnosticreport/DiagnosticReportTransformer.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/diagnosticreport/DiagnosticReportTransformer.java
@@ -7,8 +7,11 @@ import static gov.va.api.health.argonaut.service.controller.Transformers.convert
 import static gov.va.api.health.argonaut.service.controller.Transformers.ifPresent;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+import gov.va.api.health.argonaut.api.DataAbsentReason;
+import gov.va.api.health.argonaut.api.DataAbsentReason.Reason;
 import gov.va.api.health.argonaut.api.datatypes.CodeableConcept;
 import gov.va.api.health.argonaut.api.datatypes.Coding;
+import gov.va.api.health.argonaut.api.elements.Extension;
 import gov.va.api.health.argonaut.api.elements.Reference;
 import gov.va.api.health.argonaut.api.resources.DiagnosticReport;
 import gov.va.api.health.argonaut.service.controller.EnumSearcher;
@@ -103,8 +106,29 @@ public class DiagnosticReportTransformer implements DiagnosticReportController.T
         .encounter(reference(source.getEncounter()))
         .effectiveDateTime(asDateTimeString(source.getEffective()))
         .issued(asDateTimeString(source.getIssued()))
-        .performer(reference(source.getPerformer()))
+        .performer(performer(source.getPerformer()))
+        ._performer(performerExtenstion(source.getPerformer()))
         .build();
+  }
+
+  Reference performer(CdwReference maybeSource) {
+    if (maybeSource == null || allNull(maybeSource.getReference(), maybeSource.getDisplay())) {
+      return null;
+    }
+    return convert(
+        maybeSource,
+        source ->
+            Reference.builder()
+                .reference(source.getReference())
+                .display(source.getDisplay())
+                .build());
+  }
+
+  Extension performerExtenstion(CdwReference source) {
+    if (source == null) {
+      return DataAbsentReason.of(Reason.unknown);
+    }
+    return null;
   }
 
   Reference reference(CdwReference maybeSource) {

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/diagnosticreport/DiagnosticReportTransformerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/diagnosticreport/DiagnosticReportTransformerTest.java
@@ -74,6 +74,15 @@ public class DiagnosticReportTransformerTest {
   }
 
   @Test
+  public void performer() {
+    assertThat(tx.performer(cdw.cdwReference())).isEqualTo(expected.reference());
+    assertThat(tx.performer(null)).isNull();
+    assertThat(tx.performer(new CdwReference())).isNull();
+    // _performer
+    assertThat(tx.performerExtenstion(null)).isEqualTo(DataAbsentReason.of(Reason.unknown));
+  }
+
+  @Test
   public void status() {
     assertThat(tx.status(cdw.status())).isEqualTo(expected.status());
     assertThat(tx.status(CdwDiagnosticReportStatus.APPENDED)).isEqualTo(Code.appended);

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/diagnosticreport/DiagnosticReportTransformerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/diagnosticreport/DiagnosticReportTransformerTest.java
@@ -80,6 +80,7 @@ public class DiagnosticReportTransformerTest {
     assertThat(tx.performer(new CdwReference())).isNull();
     // _performer
     assertThat(tx.performerExtenstion(null)).isEqualTo(DataAbsentReason.of(Reason.unknown));
+    assertThat(tx.performerExtenstion(cdw.cdwReference())).isNull();
   }
 
   @Test

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/diagnosticreport/DiagnosticReportTransformerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/diagnosticreport/DiagnosticReportTransformerTest.java
@@ -3,6 +3,8 @@ package gov.va.api.health.argonaut.service.controller.diagnosticreport;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import gov.va.api.health.argonaut.api.DataAbsentReason;
+import gov.va.api.health.argonaut.api.DataAbsentReason.Reason;
 import gov.va.api.health.argonaut.api.datatypes.CodeableConcept;
 import gov.va.api.health.argonaut.api.datatypes.Coding;
 import gov.va.api.health.argonaut.api.elements.Reference;
@@ -67,6 +69,8 @@ public class DiagnosticReportTransformerTest {
   @Test
   public void diagnosticReport() {
     assertThat(tx.apply(cdw.diagnosticReport())).isEqualTo(expected.diagnosticReport());
+    assertThat(tx.apply(cdw.diagnosticReportNullPerformer()))
+        .isEqualTo(expected.diagnosticReportNullPerformer());
   }
 
   @Test
@@ -136,6 +140,22 @@ public class DiagnosticReportTransformerTest {
       return sampleDR;
     }
 
+    CdwDiagnosticReport102Root.CdwDiagnosticReports.CdwDiagnosticReport
+        diagnosticReportNullPerformer() {
+      CdwDiagnosticReport102Root.CdwDiagnosticReports.CdwDiagnosticReport sampleDR =
+          new CdwDiagnosticReport102Root.CdwDiagnosticReports.CdwDiagnosticReport();
+      sampleDR.setCdwId("5d582505-650e-58b3-8673-49138f7b2b04");
+      sampleDR.setStatus(status());
+      sampleDR.setCategory(category());
+      sampleDR.setCode(code());
+      sampleDR.setSubject(cdwReference());
+      sampleDR.setEncounter(cdwReference());
+      sampleDR.setEffective(effective());
+      sampleDR.setIssued(issued());
+      sampleDR.setPerformer(null);
+      return sampleDR;
+    }
+
     private CdwDiagnosticReportStatus status() {
       return CdwDiagnosticReportStatus.FINAL;
     }
@@ -165,6 +185,21 @@ public class DiagnosticReportTransformerTest {
           .effectiveDateTime("2013-06-21T19:03:16Z")
           .issued("2013-06-21T20:05:12Z")
           .performer(reference())
+          .build();
+    }
+
+    DiagnosticReport diagnosticReportNullPerformer() {
+      return DiagnosticReport.builder()
+          .resourceType("DiagnosticReport")
+          .id("5d582505-650e-58b3-8673-49138f7b2b04")
+          .status(status())
+          .category(category())
+          .code(code())
+          .subject(reference())
+          .encounter(reference())
+          .effectiveDateTime("2013-06-21T19:03:16Z")
+          .issued("2013-06-21T20:05:12Z")
+          ._performer(DataAbsentReason.of(Reason.unknown))
           .build();
     }
 


### PR DESCRIPTION
Diagnostic Report has a required practitioner/organization reference field performer. A null value for this field will cause an invalid payload error. To prevent this, a data absent reason needs to be returned instead.
Related story: https://vasdvp.atlassian.net/browse/API-593