### PR TITLE
task/API-604 Update the Jargonaut Smart-On-Fhir documentation link in conformance

### DIFF
--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/conformance/MetadataController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/conformance/MetadataController.java
@@ -166,7 +166,7 @@ class MetadataController {
         .extension(
             singletonList(
                 Extension.builder()
-                    .url("http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris")
+                    .url("http://www.hl7.org/fhir/smart-app-launch/index.html")
                     .extension(
                         asList(
                             Extension.builder()

--- a/argonaut/src/test/resources/old-conformance.json
+++ b/argonaut/src/test/resources/old-conformance.json
@@ -47,7 +47,7 @@
                 "description": "This is the conformance statement to declare that the server supports SMART-on-FHIR. See the SMART-on-FHIR docs for the extension that would go with such a server.",
                 "extension": [
                     {
-                        "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris",
+                        "url": "http://www.hl7.org/fhir/smart-app-launch/index.html",
                         "extension": [
                             {
                                 "url": "token",


### PR DESCRIPTION
The Jargonaut Smart-On-Fhir documentation has been updated from http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris to http://www.hl7.org/fhir/smart-app-launch/index.html. This change needs to be reflected in the conformance statement.
Related story: https://vasdvp.atlassian.net/browse/API-604