### PR TITLE
Support application/json+fhir

### DIFF
--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/config/FhirMediaTypesConfig.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/config/FhirMediaTypesConfig.java
@@ -1,0 +1,43 @@
+package gov.va.api.health.argonaut.service.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * This configures spring to support additional, custom HTTP media types for FHIR. We need to
+ * support application/json, application/fhir+json, and application/json+fhir. Out of the box,
+ * Spring will support application/*+json, but special configuration is needed for
+ * application/json+fhir
+ */
+@Configuration
+public class FhirMediaTypesConfig implements WebMvcConfigurer {
+
+  private static final MediaType JSON_FHIR = MediaType.parseMediaType("application/json+fhir");
+
+  @Override
+  public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+
+    /*
+     * Augment the standard Jackson mapper to also support application/json+fhir.
+     */
+    Optional<MappingJackson2HttpMessageConverter> jackson =
+        converters
+            .stream()
+            .filter(c -> c instanceof MappingJackson2HttpMessageConverter)
+            .map(c -> (MappingJackson2HttpMessageConverter) c)
+            .findFirst();
+
+    if (jackson.isPresent()) {
+      List<MediaType> moreMediaTypes = new ArrayList<>();
+      moreMediaTypes.addAll(jackson.get().getSupportedMediaTypes());
+      moreMediaTypes.add(JSON_FHIR);
+      jackson.get().setSupportedMediaTypes(moreMediaTypes);
+    }
+  }
+}

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/FhirTestClient.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/FhirTestClient.java
@@ -95,6 +95,7 @@ public class FhirTestClient implements TestClient {
     return service()
         .requestSpecification()
         .contentType(contentType)
+        .accept(contentType)
         .request(Method.GET, path, params);
   }
 


### PR DESCRIPTION
- Addresses error in Sentinel tests that were submitting a 'Content-Type' request header instead of 'Accept' for tests
- Addresses exception in Argonaut when Accept header with value application/json+fhir is requested

While fixing this, I verified the changes in Sentinel (adding the accept) line without the additional Spring Boot configuration indeed throws an exception.

@jgarnhart-va @aparcel-va This is part 1 of 3 issues that caused us downtime while updating prod.