### PR TITLE
add logic and tests for case of two deceased values

### DIFF
--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/patient/PatientTransformer.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/patient/PatientTransformer.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import javax.xml.datatype.XMLGregorianCalendar;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
@@ -330,7 +331,7 @@ public class PatientTransformer implements PatientController.Transformer {
         .address(addresses(source.getAddresses()))
         .gender(gender(source.getGender()))
         .birthDate(asDateString(source.getBirthDate()))
-        .deceasedBoolean(source.isDeceasedBoolean())
+        .deceasedBoolean(deceasedBoolean(source.getDeceasedDateTime(),source.isDeceasedBoolean()))
         .deceasedDateTime(asDateTimeString(source.getDeceasedDateTime()))
         .maritalStatus(maritalStatus(source.getMaritalStatus()))
         .contact(contacts(source.getContacts()))
@@ -366,6 +367,15 @@ public class PatientTransformer implements PatientController.Transformer {
 
   Gender gender(CdwAdministrativeGenderCodes source) {
     return ifPresent(source, gender -> EnumSearcher.of(Patient.Gender.class).find(gender.value()));
+  }
+
+  Boolean deceasedBoolean (XMLGregorianCalendar deceasedDateTime, Boolean deceasedBoolean){
+    if (deceasedDateTime == null){
+      return deceasedBoolean;
+    }
+    else{
+      return null;
+    }
   }
 
   private Boolean isUnusableContactAddress(CdwContact source) {

--- a/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/patient/PatientTransformerTest.java
+++ b/argonaut/src/test/java/gov/va/api/health/argonaut/service/controller/patient/PatientTransformerTest.java
@@ -165,6 +165,17 @@ public class PatientTransformerTest {
   }
 
   @Test
+  public void deceasedBoolean() {
+    assertThat(tx.deceasedBoolean(null, null)).isNull();
+    assertThat(tx.deceasedBoolean(cdw.patient().getDeceasedDateTime(), null)).isNull();
+    assertThat(tx.deceasedBoolean(cdw.patient().getDeceasedDateTime(), true)).isNull();
+    assertThat(tx.deceasedBoolean(cdw.patient().getDeceasedDateTime(), false)).isNull();
+    assertThat(tx.deceasedBoolean(null, true)).isTrue();
+    assertThat(tx.deceasedBoolean(null, false)).isFalse();
+
+  }
+
+  @Test
   public void identifier() {
     assertThat(tx.identifiers(singletonList(cdw.identifier()))).isEqualTo(expected.identifier());
     assertThat(tx.identifiers(Collections.emptyList())).isNull();


### PR DESCRIPTION
Related Story - https://vasdvp.atlassian.net/browse/API-656

- If both deceased values are populated, make the deceasedBoolean null.