### PR TITLE
Task/api 678 cdw crawler

### DIFF
--- a/sentinel/pom.xml
+++ b/sentinel/pom.xml
@@ -17,7 +17,7 @@
     <selenium.version>3.141.59</selenium.version>
     <!-- JUnit -->
     <groups/>
-    <excludedGroups>gov.va.health.api.sentinel.categories.Lab</excludedGroups>
+    <excludedGroups>gov.va.health.api.sentinel.categories.Lab,gov.va.health.api.sentinel.categories.CrawlProd,gov.va.health.api.sentinel.categories.CrawlQa</excludedGroups>
     <!-- Docker -->
     <docker-maven-plugin.version>0.24.0</docker-maven-plugin.version>
     <docker.organization>vasdvp</docker.organization>
@@ -412,7 +412,7 @@
       <properties>
         <sentinel.skipLaunch>true</sentinel.skipLaunch>
         <groups>gov.va.health.api.sentinel.categories.Lab</groups>
-        <excludedGroups/>
+        <excludedGroups>gov.va.health.api.sentinel.categories.CrawlProd,gov.va.health.api.sentinel.categories.CrawlQa</excludedGroups>
         <skipITs>true</skipITs>
       </properties>
     </profile>

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/ServiceDefinition.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/ServiceDefinition.java
@@ -17,6 +17,12 @@ import lombok.extern.slf4j.Slf4j;
 @Builder
 @AllArgsConstructor
 public class ServiceDefinition {
+  static {
+    log.info(
+        "Using jargonaut header is {} (Override -Djargonaut=true|false)",
+        System.getProperty("jargonaut", "unset"));
+  }
+
   String url;
   int port;
   Supplier<Optional<String>> accessToken;
@@ -29,7 +35,7 @@ public class ServiceDefinition {
             .relaxedHTTPSValidation()
             .log()
             .ifValidationFails();
-    String jargonaut = System.getenv("jargonaut");
+    String jargonaut = System.getProperty("jargonaut");
     if (isNotBlank(jargonaut)) {
       spec.header("jargonaut", jargonaut);
     }

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/categories/CrawlProd.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/categories/CrawlProd.java
@@ -1,0 +1,3 @@
+package gov.va.health.api.sentinel.categories;
+
+public interface CrawlProd {}

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/categories/CrawlQa.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/categories/CrawlQa.java
@@ -1,0 +1,3 @@
+package gov.va.health.api.sentinel.categories;
+
+public interface CrawlQa {}

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/AppointmentIT.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/AppointmentIT.java
@@ -13,19 +13,6 @@ public class AppointmentIT {
   ResourceVerifier verifier = ResourceVerifier.get();
 
   @Test
-  @Category({Prod.class})
-  public void basic() {
-    verifier.verifyAll(
-        test(200, Appointment.class, "/api/Appointment/{id}", verifier.ids().appointment()),
-        test(404, OperationOutcome.class, "/api/Appointment/{id}", verifier.ids().unknown()),
-        test(
-            200,
-            Appointment.Bundle.class,
-            "/api/Appointment?patient={patient}",
-            verifier.ids().patient()));
-  }
-
-  @Test
   public void advanced() {
     verifier.verifyAll(
         test(
@@ -38,6 +25,19 @@ public class AppointmentIT {
             200,
             Appointment.Bundle.class,
             "/api/Appointment?identifier={id}",
-            verifier.ids().appointment()));
+            verifier.ids().appointment()),
+        test(
+            200,
+            Appointment.Bundle.class,
+            "/api/Appointment?patient={patient}",
+            verifier.ids().patient()));
+  }
+
+  @Test
+  @Category({Prod.class})
+  public void basic() {
+    verifier.verifyAll(
+        test(200, Appointment.class, "/api/Appointment/{id}", verifier.ids().appointment()),
+        test(404, OperationOutcome.class, "/api/Appointment/{id}", verifier.ids().unknown()));
   }
 }

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/CdwCrawlerTest.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/CdwCrawlerTest.java
@@ -71,7 +71,7 @@ public class CdwCrawlerTest {
             .forceJargonaut(true)
             .build();
     crawler.crawl();
-    log.info("Results for {} ({})\n{}", patient, results.message());
+    log.info("Results for patient : {} \n{}", patient, results.message());
     assertThat(results.failures()).withFailMessage("%d Failures", results.failures()).isEqualTo(0);
   }
 

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/CdwCrawlerTest.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/CdwCrawlerTest.java
@@ -1,0 +1,89 @@
+package gov.va.health.api.sentinel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gov.va.health.api.sentinel.categories.CrawlProd;
+import gov.va.health.api.sentinel.categories.CrawlQa;
+import gov.va.health.api.sentinel.crawler.ConcurrentRequestQueue;
+import gov.va.health.api.sentinel.crawler.Crawler;
+import gov.va.health.api.sentinel.crawler.FileResultsCollector;
+import gov.va.health.api.sentinel.crawler.RequestQueue;
+import gov.va.health.api.sentinel.crawler.ResourceDiscovery;
+import gov.va.health.api.sentinel.crawler.SummarizingResultCollector;
+import java.io.File;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Slf4j
+public class CdwCrawlerTest {
+  private static final String SAPIDER =
+      "\n"
+          + "                   /\\\n"
+          + "                  /  \\\n"
+          + "                 |  _ \\                  _\n"
+          + "                 | / \\ \\                / \\\n"
+          + "                 |/   \\ \\              /   \\\n"
+          + "                 /     \\ |        /\\  /     \\\n"
+          + "                /|      \\| ~  ~  /  \\/       \\\n"
+          + "        _______/_|_______\\(o)(o)/___/\\_____   \\\n"
+          + "       /      /  |       (______)     \\    \\   \\_\n"
+          + "      /      /   |                     \\    \\\n"
+          + "     /      /    |                      \\    \\\n"
+          + "    /      /     |                       \\    \\\n"
+          + "   /     _/      |                        \\    \\\n"
+          + "  /             _|                         \\    \\_\n"
+          + "_/                                          \\\n"
+          + "                                             \\\n"
+          + "                                              \\_"
+          + "\n";
+
+  private void crawl(SystemDefinition env) {
+    String patient = System.getProperty("patient-id", "1011537977V693883");
+    log.info("Using patient {} (Override with -Dpatient-id=<id>)", patient);
+
+    log.info(
+        "\n\n                     SWIGGITY SWOOTY!\n"
+            + SAPIDER
+            + "\n          doot! doot! "
+            + "Using patient {} (Override with -Dpatient-id=<value>)\n",
+        patient);
+
+    Supplier<String> accessTokenValue = () -> env.argonaut().accessToken().get().get();
+    assertThat(accessTokenValue).isNotNull();
+    log.info("Access token is specified");
+
+    ResourceDiscovery discovery =
+        ResourceDiscovery.builder().patientId(patient).url(env.argonaut().url() + "/api").build();
+    SummarizingResultCollector results =
+        SummarizingResultCollector.wrap(
+            new FileResultsCollector(new File("target/cdw-crawl-" + patient)));
+    RequestQueue q = new ConcurrentRequestQueue();
+    discovery.queries().forEach(q::add);
+    Crawler crawler =
+        Crawler.builder()
+            .executor(Executors.newFixedThreadPool(4))
+            .requestQueue(q)
+            .results(results)
+            .authenticationToken(accessTokenValue)
+            .forceJargonaut(true)
+            .build();
+    crawler.crawl();
+    log.info("Results for {} ({})\n{}", patient, results.message());
+    assertThat(results.failures()).withFailMessage("%d Failures", results.failures()).isEqualTo(0);
+  }
+
+  @Category(CrawlQa.class)
+  @Test
+  public void crawlQa() {
+    crawl(SystemDefinitions.get().qa());
+  }
+
+  @Category(CrawlProd.class)
+  @Test
+  public void crawlProd() {
+    crawl(SystemDefinitions.get().prod());
+  }
+}


### PR DESCRIPTION
Related Stories : 
- https://vasdvp.atlassian.net/browse/API-638
    - https://vasdvp.atlassian.net/browse/API-678
    - https://vasdvp.atlassian.net/browse/API-679

Adds test for sAPIder to crawl prod and qa along with their own categories to specify when they should be run as they are time consuming.

Some category or profile adjustments may need to be made. 