### PR TITLE
task/API-709 Edit Dockerfile to force executable permission to sentinel scripts

### DIFF
--- a/sentinel/src/main/docker/Dockerfile
+++ b/sentinel/src/main/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM vasdvp/health-apis-maven:latest
 
 COPY maven/ /sentinel
+RUN chmod 755 /sentinel/*sh
 ENTRYPOINT ["/sentinel/entrypoint.sh"]
 CMD []


### PR DESCRIPTION
During Windows builds, sentinel scripts are losing their executable permission and causing a failure for docker run commands. Edited Dockerfile to force permission.
Related story: https://vasdvp.atlassian.net/browse/API-709