### PR TITLE
Added env parsing to sentinel. Refactored patient read test to be smrter

### DIFF
--- a/sentinel/src/main/java/gov/va/health/api/sentinel/Sentinel.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/Sentinel.java
@@ -20,23 +20,43 @@ public class Sentinel {
     log.info("Using {} Sentinel environment (Override with -Dsentinel=LOCAL|QA|PROD)", env);
   }
 
+  public enum Environment {
+    LOCAL,
+    PROD,
+    QA
+  }
+
   private SystemDefinition system;
+
+  /** Parse the system property 'sentinel' into the appropriate enum. */
+  public static Environment environment() {
+    String env = System.getProperty("sentinel", "LOCAL").toUpperCase(Locale.ENGLISH);
+    switch (env) {
+      case "LOCAL":
+        return Environment.LOCAL;
+      case "PROD":
+        return Environment.PROD;
+      case "QA":
+        return Environment.QA;
+      default:
+        throw new IllegalArgumentException("Unknown sentinel environment: " + env);
+    }
+  }
 
   /**
    * Create a new Sentinel configured with the system definition based on the environment specified
    * by the `sentinel` system property.
    */
   public static Sentinel get() {
-    String env = System.getProperty("sentinel", "LOCAL").toUpperCase(Locale.ENGLISH);
-    switch (env) {
-      case "LOCAL":
+    switch (environment()) {
+      case LOCAL:
         return new Sentinel(SystemDefinitions.get().local());
-      case "PROD":
+      case PROD:
         return new Sentinel(SystemDefinitions.get().prod());
-      case "QA":
+      case QA:
         return new Sentinel(SystemDefinitions.get().qa());
       default:
-        throw new IllegalArgumentException("Unknown sentinel environment: " + env);
+        throw new IllegalArgumentException("Unknown sentinel environment: " + environment());
     }
   }
 

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/PatientIT.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/PatientIT.java
@@ -4,6 +4,7 @@ import static gov.va.health.api.sentinel.ResourceVerifier.test;
 
 import gov.va.api.health.argonaut.api.resources.OperationOutcome;
 import gov.va.api.health.argonaut.api.resources.Patient;
+import gov.va.health.api.sentinel.Sentinel.Environment;
 import gov.va.health.api.sentinel.categories.Prod;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -46,9 +47,24 @@ public class PatientIT {
   public void basic() {
     verifier.verifyAll(
         test(200, Patient.class, "/api/Patient/{id}", verifier.ids().patient()),
-        test(404, OperationOutcome.class, "/api/Patient/{id}", verifier.ids().unknown()),
         test(200, Patient.Bundle.class, "/api/Patient?_id={id}", verifier.ids().patient()),
         test(200, Patient.Bundle.class, "/api/Patient?identifier={id}", verifier.ids().patient()),
         test(404, OperationOutcome.class, "/api/Patient?_id={id}", verifier.ids().unknown()));
+  }
+
+  /**
+   * In the PROD/QA environments, patient reading is restricted to your unique access-token. Any IDs
+   * but your own are revoked with a 403 Forbidden. In environments where this restriction is
+   * lifted, the result of an unknown ID should be 404 Not Found.
+   */
+  @Test
+  public void patientMatching() {
+    if (Sentinel.environment() == Environment.LOCAL) {
+      verifier.verify(
+          test(404, OperationOutcome.class, "/api/Patient/{id}", verifier.ids().unknown()));
+    } else {
+      verifier.verify(
+          test(403, OperationOutcome.class, "/api/Patient/{id}", verifier.ids().unknown()));
+    }
   }
 }


### PR DESCRIPTION
Added logic around the unknown patient search test to handle when patient validation is on or off.
403 forbidden in qa/prod
404 not found in local ie... sandbox