### PR TITLE
API-712 fail health-apis build on compiler warnings

### DIFF
--- a/argonaut-api/src/main/java/gov/va/api/health/argonaut/api/resources/Practitioner.java
+++ b/argonaut-api/src/main/java/gov/va/api/health/argonaut/api/resources/Practitioner.java
@@ -20,7 +20,6 @@ import gov.va.api.health.argonaut.api.elements.Extension;
 import gov.va.api.health.argonaut.api.elements.Meta;
 import gov.va.api.health.argonaut.api.elements.Narrative;
 import gov.va.api.health.argonaut.api.elements.Reference;
-import gov.va.api.health.argonaut.api.resources.Medication.Entry;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import javax.validation.Valid;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/config/ArgonautJacksonMapper.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/config/ArgonautJacksonMapper.java
@@ -2,7 +2,6 @@ package gov.va.api.health.argonaut.service.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,7 +10,6 @@ import org.springframework.context.annotation.Configuration;
  * This mapper provides additional configuration that treats Argonaut Reference objects special. It
  * will fully qualify relative reference links.
  */
-@Slf4j
 @Configuration
 public class ArgonautJacksonMapper {
 

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/config/MagicReferenceConfig.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/config/MagicReferenceConfig.java
@@ -201,6 +201,7 @@ public class MagicReferenceConfig {
             }
 
             @Override
+            @SuppressWarnings("unchecked")
             public JsonSerializer<?> modifySerializer(
                 SerializationConfig config,
                 BeanDescription beanDesc,

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/allergyintolerance/AllergyIntoleranceController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/allergyintolerance/AllergyIntoleranceController.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -43,7 +42,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class AllergyIntoleranceController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/appointment/AppointmentController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/appointment/AppointmentController.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -43,7 +42,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class AppointmentController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/condition/ConditionController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/condition/ConditionController.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -42,7 +41,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class ConditionController {
   private Transformer transformer;
   private MrAndersonClient mrAndersonClient;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/conformance/MetadataController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/conformance/MetadataController.java
@@ -30,7 +30,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
 import lombok.Value;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,7 +41,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 class MetadataController {
 
   private static final String ALLERGYINTOLERANCE_HTML =

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/diagnosticreport/DiagnosticReportController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/diagnosticreport/DiagnosticReportController.java
@@ -22,7 +22,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -47,7 +46,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class DiagnosticReportController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/encounter/EncounterController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/encounter/EncounterController.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -41,7 +40,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class EncounterController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/immunization/ImmunizationController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/immunization/ImmunizationController.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -42,7 +41,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class ImmunizationController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/location/LocationController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/location/LocationController.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -42,7 +41,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class LocationController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/medication/MedicationController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/medication/MedicationController.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -42,7 +41,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class MedicationController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/medicationorder/MedicationOrderController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/medicationorder/MedicationOrderController.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -43,7 +42,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class MedicationOrderController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/medicationstatement/MedicationStatementController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/medicationstatement/MedicationStatementController.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -42,7 +41,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class MedicationStatementController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/observation/ObservationController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/observation/ObservationController.java
@@ -20,7 +20,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -45,7 +44,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class ObservationController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/organization/OrganizationController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/organization/OrganizationController.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -42,7 +41,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class OrganizationController {
   private Transformer transformer;
   private MrAndersonClient mrAndersonClient;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/patient/PatientController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/patient/PatientController.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -44,7 +43,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class PatientController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/practitioner/PractitionerController.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -42,7 +41,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class PractitionerController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/procedure/ProcedureController.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/controller/procedure/ProcedureController.java
@@ -20,7 +20,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -44,7 +43,6 @@ import org.springframework.web.bind.annotation.RestController;
   produces = {"application/json", "application/json+fhir", "application/fhir+json"}
 )
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
-@Slf4j
 public class ProcedureController {
 
   private Transformer transformer;

--- a/argonaut/src/main/java/gov/va/api/health/argonaut/service/mranderson/client/RestMrAndersonClient.java
+++ b/argonaut/src/main/java/gov/va/api/health/argonaut/service/mranderson/client/RestMrAndersonClient.java
@@ -2,7 +2,6 @@ package gov.va.api.health.argonaut.service.mranderson.client;
 
 import gov.va.api.health.argonaut.service.config.WithJaxb;
 import java.util.Collections;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
@@ -18,7 +17,6 @@ import org.springframework.web.client.RestTemplate;
 
 /** A rest implementation of the Mr. Anderson client. */
 @Component
-@Slf4j
 public class RestMrAndersonClient implements MrAndersonClient {
   private final RestTemplate restTemplate;
 

--- a/mr-anderson/src/main/java/gov/va/api/health/mranderson/cdw/impl/IdentityParameterReplacer.java
+++ b/mr-anderson/src/main/java/gov/va/api/health/mranderson/cdw/impl/IdentityParameterReplacer.java
@@ -9,11 +9,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Singular;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 /** Leverages the Identity Service to replace _identifier_ type parameters in Queries. */
+@SuppressWarnings("all")
 class IdentityParameterReplacer {
 
   private final IdentityService identityService;
@@ -24,10 +27,16 @@ class IdentityParameterReplacer {
   private IdentityParameterReplacer(
       IdentityService identityService,
       @Singular Set<String> identityKeys,
-      @Singular Map<String, String> aliases) {
+      @Singular List<Pair<String, String>> aliases) {
     this.identityService = identityService;
     this.identityKeys = identityKeys;
-    this.aliases = aliases;
+
+    // @Singular Map<String, String> emits a compiler warning from the Lombok code (??)
+    // List of pairs is a workaround.
+    this.aliases =
+        aliases
+            .stream()
+            .collect(Collectors.toMap(alias -> alias.getKey(), alias -> alias.getValue()));
   }
 
   private String aliasOf(String key) {

--- a/mr-anderson/src/main/java/gov/va/api/health/mranderson/cdw/impl/IdentityParameterReplacer.java
+++ b/mr-anderson/src/main/java/gov/va/api/health/mranderson/cdw/impl/IdentityParameterReplacer.java
@@ -16,7 +16,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 /** Leverages the Identity Service to replace _identifier_ type parameters in Queries. */
-@SuppressWarnings("all")
 class IdentityParameterReplacer {
 
   private final IdentityService identityService;

--- a/mr-anderson/src/main/java/gov/va/api/health/mranderson/cdw/impl/WitnessProtectionResources.java
+++ b/mr-anderson/src/main/java/gov/va/api/health/mranderson/cdw/impl/WitnessProtectionResources.java
@@ -9,6 +9,7 @@ import gov.va.api.health.mranderson.util.XmlDocuments.ParseFailed;
 import gov.va.api.health.mranderson.util.XmlDocuments.WriteFailed;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.w3c.dom.Document;
@@ -57,7 +58,7 @@ public class WitnessProtectionResources implements Resources {
           .identityKey("identifier")
           .identityKey("identifier:exact")
           .identityKey("_id")
-          .alias("_id", "identifier")
+          .alias(Pair.of("_id", "identifier"))
           .build()
           .rebuildWithCdwIdentities(originalQuery);
     } catch (IdentityService.LookupFailed e) {

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,32 @@
       </activation>
       <build>
         <plugins>
+          <!-- Compiler -->
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>${maven-compiler-plugin.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <!-- Enable warnings for compile goal. (Not testCompile.) -->
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <source>${java.version}</source>
+                  <target>${java.version}</target>
+                  <showWarnings>true</showWarnings>
+                  <compilerArgs>
+                    <arg>-Xlint:all</arg>
+                    <!-- Suppress unknown annotation processing warnings. -->
+                    <arg>-Xlint:-processing</arg>
+                    <!-- Java serialization is not used. -->
+                    <arg>-Xlint:-serial</arg>
+                    <arg>-Werror</arg>
+                  </compilerArgs>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <!-- Maven Enforcer rules that apply to all projects. -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -284,6 +310,7 @@
               </execution>
             </executions>
           </plugin>
+          <!-- Checkstyle -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/ExpectedResponse.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/ExpectedResponse.java
@@ -10,7 +10,6 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import lombok.AllArgsConstructor;
 import lombok.Value;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * A decorator for the standard Rest Assured response that adds a little more error support, by
@@ -18,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Value
 @AllArgsConstructor(staticName = "of")
-@Slf4j
 class ExpectedResponse {
 
   Response response;

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/FhirTestClient.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/FhirTestClient.java
@@ -23,7 +23,7 @@ public class FhirTestClient implements TestClient {
    * Remove data from the OO that is unique for each instance. This includes the generated ID and
    * the timestamp.
    */
-  private OperationOutcome asOperationOutcomeWithoutDiagnostics(ResponseBody body) {
+  private OperationOutcome asOperationOutcomeWithoutDiagnostics(ResponseBody<?> body) {
     try {
       OperationOutcome oo = body.as(OperationOutcome.class);
       oo.id("REMOVED-FOR-COMPARISON");

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/ServiceDefinition.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/ServiceDefinition.java
@@ -9,8 +9,10 @@ import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
 
 /** Defines particulars for interacting with a specific service. */
+@Slf4j
 @Value
 @Builder
 @AllArgsConstructor

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/ServiceDefinition.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/ServiceDefinition.java
@@ -9,10 +9,8 @@ import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
-import lombok.extern.slf4j.Slf4j;
 
 /** Defines particulars for interacting with a specific service. */
-@Slf4j
 @Value
 @Builder
 @AllArgsConstructor

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/SystemDefinition.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/SystemDefinition.java
@@ -3,12 +3,10 @@ package gov.va.health.api.sentinel;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
-import lombok.extern.slf4j.Slf4j;
 
 /** Specifies the particulars for interacting with the different services within a system. */
 @Value
 @Builder
-@Slf4j
 public class SystemDefinition {
   @NonNull ServiceDefinition ids;
   @NonNull ServiceDefinition mrAnderson;

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/Crawler.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/Crawler.java
@@ -3,7 +3,6 @@ package gov.va.health.api.sentinel.crawler;
 import static java.util.stream.Collectors.joining;
 
 import gov.va.api.health.argonaut.api.bundle.AbstractBundle;
-import gov.va.api.health.argonaut.api.bundle.AbstractEntry;
 import gov.va.api.health.argonaut.api.bundle.BundleLink;
 import gov.va.api.health.argonaut.api.bundle.BundleLink.LinkRelation;
 import gov.va.health.api.sentinel.crawler.Result.Outcome;
@@ -51,7 +50,7 @@ public class Crawler {
     if (next.isPresent()) {
       requestQueue.add(next.get().url());
     }
-    bundle.entry().stream().map(AbstractEntry::fullUrl).forEach(requestQueue::add);
+    bundle.entry().stream().map(entry -> entry.fullUrl()).forEach(requestQueue::add);
   }
 
   private String asAdditionalInfo(ConstraintViolation<?> v) {

--- a/service-auto-config/src/main/java/gov/va/api/health/autoconfig/configuration/JacksonConfig.java
+++ b/service-auto-config/src/main/java/gov/va/api/health/autoconfig/configuration/JacksonConfig.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -67,7 +66,6 @@ import org.springframework.context.annotation.Configuration;
  * </pre>
  */
 @Configuration
-@Slf4j
 public class JacksonConfig {
 
   /** Return a configured Jackson ObjectMapper. This method is useful as a supplier function. */

--- a/service-auto-config/src/main/java/gov/va/api/health/autoconfig/configuration/JacksonConfig.java
+++ b/service-auto-config/src/main/java/gov/va/api/health/autoconfig/configuration/JacksonConfig.java
@@ -166,7 +166,7 @@ public class JacksonConfig {
             @Override
             public void serialize(String value, JsonGenerator gen, SerializerProvider provider)
                 throws IOException {
-              gen.writeString(trim((String) value));
+              gen.writeString(trim(value));
             }
           });
     }


### PR DESCRIPTION
Enable `javac` compiler warnings and make them fail the build. Only main source files are analzyed, not test code.

The `serial` warning, which warns about missing `serialVersionUID` definitions on serializable classes, is suppressed. 

The `processing` warning is also suppressed. Those warnings looks like this:

```
[WARNING] No processor claimed any of these annotations:
org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean,
org.springframework.beans.factory.annotation.Autowired,
org.springframework.boot.context.properties.ConfigurationProperties,
org.springframework.context.annotation.Configuration,
org.springframework.boot.context.properties.EnableConfigurationProperties,
org.springframework.context.annotation.Bean
```

These warnings are caused by Lombok's annotation processor not recognizing various Spring Boot annotations. I think they are benign. More info [here](https://github.com/spring-projects/spring-boot/issues/6421
)
