### PR TITLE
Updated logging of sentinel tests to look like this:

### DIFF
--- a/sentinel/src/test/java/gov/va/health/api/sentinel/ResourceVerifier.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/ResourceVerifier.java
@@ -37,6 +37,7 @@ public class ResourceVerifier {
     if (!AbstractBundle.class.isAssignableFrom(tc.response())) {
       return;
     }
+    log.info("Verify {} page bounds", tc.label());
     argonaut()
         .get(tc.path() + "&page=0", tc.parameters())
         .expect(400)
@@ -53,6 +54,7 @@ public class ResourceVerifier {
   }
 
   public <T> T assertRequest(TestCase<T> tc) {
+    log.info("Verify {} is {} ({})", tc.label(), tc.response().getSimpleName(), tc.status());
     return argonaut()
         .get(tc.path(), tc.parameters())
         .expect(tc.status())
@@ -65,7 +67,6 @@ public class ResourceVerifier {
   }
 
   public void verifyAll(TestCase<?>... testCases) {
-    log.info("Verifying {} test cases", testCases.length);
     for (TestCase tc : testCases) {
       try {
         verify(tc);
@@ -78,7 +79,6 @@ public class ResourceVerifier {
         throw e;
       }
     }
-    log.info("Verified {} test cases", testCases.length);
   }
 
   @Value
@@ -88,5 +88,9 @@ public class ResourceVerifier {
     Class<T> response;
     String path;
     String[] parameters;
+
+    String label() {
+      return path + " with " + Arrays.toString(parameters);
+    }
   }
 }

--- a/sentinel/src/test/resources/logback-test.xml
+++ b/sentinel/src/test/resources/logback-test.xml
@@ -10,4 +10,5 @@
     <appender-ref ref="STDOUT"/>
   </root>
   <logger level="INFO" name="org.apache.http"/>
+  <logger level="WARN" name="org.hibernate.validator.internal"/>
 </configuration>


### PR DESCRIPTION
```
2019-01-24 22:18:51 INFO  g.v.h.api.sentinel.ResourceVerifier - Verify /api/Patient?family={family}&gender={gender} with [VETERAN, male] page bounds
2019-01-24 22:18:52 INFO  g.v.h.api.sentinel.ResourceVerifier - Verify /api/Patient?family={family}&gender={gender} with [VETERAN, male] is Bundle (200)
2019-01-24 22:18:53 INFO  g.v.h.api.sentinel.ResourceVerifier - Verify /api/Patient?given={given}&gender={gender} with [JOHN Q, male] page bounds
2019-01-24 22:18:54 INFO  g.v.h.api.sentinel.ResourceVerifier - Verify /api/Patient?given={given}&gender={gender} with [JOHN Q, male] is Bundle (200)
```
instead of `Testing 3 cases`

Also suppressed Hibernate Validator spam.