### PR TITLE
Task/api 757 url overrides for sentinel blue green

### DIFF
--- a/sentinel/src/main/docker/entrypoint.sh
+++ b/sentinel/src/main/docker/entrypoint.sh
@@ -53,7 +53,17 @@ doTest() {
   [ -z "$tests" ] && tests=$(defaultTests)
   local filter
   [ -n "$CATEGORY" ] && filter="--filter=org.junit.experimental.categories.IncludeCategories=$CATEGORY"
-  java -cp "$(pwd)/*" $SYSTEM_PROPERTIES org.junit.runner.JUnitCore $filter $tests
+  local noise="org.junit"
+  noise+="|groovy.lang.Meta"
+  noise+="|io.restassured.filter"
+  noise+="|io.restassured.internal"
+  noise+="|java.lang.reflect"
+  noise+="|java.net"
+  noise+="|org.apache.http"
+  noise+="|org.codehaus.groovy"
+  noise+="|sun.reflect"
+  java -cp "$(pwd)/*" $SYSTEM_PROPERTIES org.junit.runner.JUnitCore $filter $tests \
+    | grep -vE "^	at ($noise)"
   exit $?
 }
 

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/ResourceVerifier.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/ResourceVerifier.java
@@ -12,8 +12,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ResourceVerifier {
   private static final ResourceVerifier INSTANCE = new ResourceVerifier();
-  @Getter private final TestClient argonaut = Sentinel.get().clients().argonaut();
-  @Getter private final TestIds ids = IdRegistrar.of(Sentinel.get().system()).registeredIds();
+
+  @Getter(lazy = true)
+  private final Sentinel sentinel = Sentinel.get();
+
+  @Getter private final TestClient argonaut = sentinel().clients().argonaut();
+  @Getter private final TestIds ids = IdRegistrar.of(sentinel().system()).registeredIds();
 
   public static ResourceVerifier get() {
     return INSTANCE;


### PR DESCRIPTION
Adds two features
1) System properties can be used to override default URLs per environment, e.g. `-Dsentinel.argonaut.url=https://green.freedomstream.io`

2) Stack traces are now filtered to make them easier to read when tests are executed in the sentinel container, e.g.

```
Time: 2.802
There were 4 failures:
1) advanced(gov.va.health.api.sentinel.PatientIT)
java.lang.ExceptionInInitializerError
	at gov.va.health.api.sentinel.PatientIT.<init>(PatientIT.java:14)
Caused by: java.net.ConnectException: Connection refused (Connection refused)
	at gov.va.health.api.sentinel.BasicTestClient.post(BasicTestClient.java:41)
	at gov.va.health.api.sentinel.IdRegistrar.registerCdwIds(IdRegistrar.java:102)
	at gov.va.health.api.sentinel.IdRegistrar.registeredIds(IdRegistrar.java:24)
	at gov.va.health.api.sentinel.ResourceVerifier.<init>(ResourceVerifier.java:20)
	at gov.va.health.api.sentinel.ResourceVerifier.<clinit>(ResourceVerifier.java:14)
	... 29 more
2) basic(gov.va.health.api.sentinel.PatientIT)
java.lang.NoClassDefFoundError: Could not initialize class gov.va.health.api.sentinel.ResourceVerifier
	at gov.va.health.api.sentinel.PatientIT.<init>(PatientIT.java:14)
3) patientIdentifierSearching(gov.va.health.api.sentinel.PatientIT)
java.lang.NoClassDefFoundError: Could not initialize class gov.va.health.api.sentinel.ResourceVerifier
	at gov.va.health.api.sentinel.PatientIT.<init>(PatientIT.java:14)
4) patientMatching(gov.va.health.api.sentinel.PatientIT)
java.lang.NoClassDefFoundError: Could not initialize class gov.va.health.api.sentinel.ResourceVerifier
	at gov.va.health.api.sentinel.PatientIT.<init>(PatientIT.java:14)

FAILURES!!!
Tests run: 4,  Failures: 4
```