### PR TITLE
Crawler support for blue/green environments

### DIFF
--- a/sentinel/src/test/java/gov/va/health/api/sentinel/LabCrawlerTest.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/LabCrawlerTest.java
@@ -20,37 +20,10 @@ import org.junit.experimental.categories.Category;
 @Slf4j
 public class LabCrawlerTest {
 
-  private static final String SAPIDER =
-      "\n"
-          + "                   /\\\n"
-          + "                  /  \\\n"
-          + "                 |  _ \\                  _\n"
-          + "                 | / \\ \\                / \\\n"
-          + "                 |/   \\ \\              /   \\\n"
-          + "                 /     \\ |        /\\  /     \\\n"
-          + "                /|      \\| ~  ~  /  \\/       \\\n"
-          + "        _______/_|_______\\(o)(o)/___/\\_____   \\\n"
-          + "       /      /  |       (______)     \\    \\   \\_\n"
-          + "      /      /   |                     \\    \\\n"
-          + "     /      /    |                      \\    \\\n"
-          + "    /      /     |                       \\    \\\n"
-          + "   /     _/      |                        \\    \\\n"
-          + "  /             _|                         \\    \\_\n"
-          + "_/                                          \\\n"
-          + "                                             \\\n"
-          + "                                              \\_"
-          + "\n";
-
   private LabRobots robots = LabRobots.fromSystemProperties();
 
   private void crawl(IdMeOauthRobot robot) {
-    log.info(
-        "\n\n                     SWIGGITY SWOOTY!\n"
-            + SAPIDER
-            + "\n          doot! doot! "
-            + robot.config().user().id()
-            + "\n");
-
+    Swiggity.swooty(robot.config().user().id());
     assertThat(robot.token().accessToken()).isNotBlank();
     ResourceDiscovery discovery =
         ResourceDiscovery.builder()

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/StagingCrawlerTest.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/StagingCrawlerTest.java
@@ -22,26 +22,6 @@ import org.junit.experimental.categories.Category;
 
 @Slf4j
 public class StagingCrawlerTest {
-  private static final String SAPIDER =
-      "\n"
-          + "                   /\\\n"
-          + "                  /  \\\n"
-          + "                 |  _ \\                  _\n"
-          + "                 | / \\ \\                / \\\n"
-          + "                 |/   \\ \\              /   \\\n"
-          + "                 /     \\ |        /\\  /     \\\n"
-          + "                /|      \\| ~  ~  /  \\/       \\\n"
-          + "        _______/_|_______\\(o)(o)/___/\\_____   \\\n"
-          + "       /      /  |       (______)     \\    \\   \\_\n"
-          + "      /      /   |                     \\    \\\n"
-          + "     /      /    |                      \\    \\\n"
-          + "    /      /     |                       \\    \\\n"
-          + "   /     _/      |                        \\    \\\n"
-          + "  /             _|                         \\    \\_\n"
-          + "_/                                          \\\n"
-          + "                                             \\\n"
-          + "                                              \\_"
-          + "\n";
 
   @Category({NotInLocal.class, NotInLab.class, NotInProd.class})
   @Test
@@ -53,13 +33,7 @@ public class StagingCrawlerTest {
 
     String patient = System.getProperty("patient-id", "1011537977V693883");
     log.info("Using patient {} (Override with -Dpatient-id=<id>)", patient);
-
-    log.info(
-        "\n\n                     SWIGGITY SWOOTY!\n"
-            + SAPIDER
-            + "\n          doot! doot! "
-            + "Using patient {} (Override with -Dpatient-id=<value>)\n",
-        patient);
+    Swiggity.swooty(patient);
 
     ResourceDiscovery discovery =
         ResourceDiscovery.builder()

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/Swiggity.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/Swiggity.java
@@ -1,0 +1,38 @@
+package gov.va.health.api.sentinel;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UtilityClass
+public class Swiggity {
+  private static final String SAPIDER =
+      "\n"
+          + "                   /\\\n"
+          + "                  /  \\\n"
+          + "                 |  _ \\                  _\n"
+          + "                 | / \\ \\                / \\\n"
+          + "                 |/   \\ \\              /   \\\n"
+          + "                 /     \\ |        /\\  /     \\\n"
+          + "                /|      \\| ~  ~  /  \\/       \\\n"
+          + "        _______/_|_______\\(o)(o)/___/\\_____   \\\n"
+          + "       /      /  |       (______)     \\    \\   \\_\n"
+          + "      /      /   |                     \\    \\\n"
+          + "     /      /    |                      \\    \\\n"
+          + "    /      /     |                       \\    \\\n"
+          + "   /     _/      |                        \\    \\\n"
+          + "  /             _|                         \\    \\_\n"
+          + "_/                                          \\\n"
+          + "                                             \\\n"
+          + "                                              \\_"
+          + "\n";
+
+  public static void swooty(String patient) {
+    log.info(
+        "\n\n                     SWIGGITY SWOOTY!\n"
+            + SAPIDER
+            + "\n          doot! doot! "
+            + "Keep on creeping on patient {}\n",
+        patient);
+  }
+}


### PR DESCRIPTION
- CdwCrawler has been updated to support optional link url overrides
- Swiggity Swooty has been extracted from the three crawlers into one

The following example shows running the crawler against an alternative URL replacing original URL links
```
docker run --rm -it vasdvp/health-apis-sentinel:bs test gov.va.health.api.sentinel.CdwCrawlerTest \
  -Daccess-token=$TOKEN \
  -Dsentinel=QA \
  -Dsentinel.argona.url=https://green.freedomstream.io  \
  -Dsentinel.argonaut.url.replace=https://qa-argonaut.lighthouse.va.gov
```