### PR TITLE
Task/api 877 lab crawler

### DIFF
--- a/sentinel/src/main/java/gov/va/health/api/sentinel/LabRobots.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/LabRobots.java
@@ -52,6 +52,14 @@ public class LabRobots {
 
     SmartOnFhirUrls urls = new SmartOnFhirUrls("https://dev-api.va.gov/services/argonaut/v0");
 
+    return makeRobot(user, urls);
+  }
+
+  /**
+   * Creates IdMeOauthRobot with specified user credentials and urls for Lab environment using
+   * Chrome Driver.
+   */
+  public IdMeOauthRobot makeRobot(UserCredentials user, SmartOnFhirUrls urls) {
     IdMeOauthRobot.Configuration config =
         IdMeOauthRobot.Configuration.builder()
             .authorization(
@@ -187,7 +195,7 @@ public class LabRobots {
   }
 
   @Value
-  private static class SmartOnFhirUrls {
+  public static class SmartOnFhirUrls {
     String token;
     String authorize;
 
@@ -196,7 +204,11 @@ public class LabRobots {
       log.info("Discovering authorization endpoints from {}", baseUrl);
 
       Conformance conformanceStatement =
-          RestAssured.given().baseUri(baseUrl).get("metadata").as(Conformance.class);
+          RestAssured.given()
+              .relaxedHTTPSValidation()
+              .baseUri(baseUrl)
+              .get("metadata")
+              .as(Conformance.class);
 
       assertThat(conformanceStatement.rest()).isNotEmpty();
       Optional<Extension> smartOnFhir =

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/ServiceDefinition.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/ServiceDefinition.java
@@ -47,4 +47,20 @@ public class ServiceDefinition {
     }
     return spec;
   }
+
+  /**
+   * Guaranteed to return a url + path that adds / as necessary to produce a url that ends in a /.
+   * e.g. https://something.com/my/cool/api/
+   */
+  String urlWithApiPath() {
+    StringBuilder builder = new StringBuilder(url());
+    if (!apiPath().startsWith("/")) {
+      builder.append('/');
+    }
+    builder.append(apiPath());
+    if (!apiPath.endsWith("/")) {
+      builder.append('/');
+    }
+    return builder.toString();
+  }
 }

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/SystemDefinitions.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/SystemDefinitions.java
@@ -60,24 +60,24 @@ public class SystemDefinitions {
     return SystemDefinition.builder()
         .ids(
             ServiceDefinition.builder()
-                .url("https://dev-api.va.gov")
+                .url(optionUrlIds("https://dev-api.va.gov"))
                 .port(443)
                 .accessToken(noAccessToken())
                 .apiPath("/not-available/")
                 .build())
         .mrAnderson(
             ServiceDefinition.builder()
-                .url("https://dev-api.va.gov")
+                .url(optionUrlMrAnderson("https://dev-api.va.gov"))
                 .port(443)
                 .accessToken(noAccessToken())
                 .apiPath("/not-available/")
                 .build())
         .argonaut(
             ServiceDefinition.builder()
-                .url("https://dev-api.va.gov")
+                .url(optionUrlArgonaut("https://dev-api.va.gov"))
                 .port(443)
                 .accessToken(magicAccessToken())
-                .apiPath("/services/argonaut/v0/")
+                .apiPath(optionApiPath("argonaut", "/services/argonaut/v0/"))
                 .build())
         .cdwIds(labAndStagingIds())
         .build();
@@ -133,7 +133,7 @@ public class SystemDefinitions {
                 .url(optionUrlArgonaut("https://localhost"))
                 .port(8090)
                 .accessToken(noAccessToken())
-                .apiPath("/api/")
+                .apiPath(optionApiPath("argonaut", "/api/"))
                 .build())
         .cdwIds(
             TestIds.builder()
@@ -184,6 +184,19 @@ public class SystemDefinitions {
         .build();
   }
 
+  private String optionApiPath(String name, String defaultValue) {
+    String property = "sentinel." + name + ".api-path";
+    String url = System.getProperty(property, defaultValue);
+    if (!url.startsWith("/")) {
+      url = "/" + url;
+    }
+    if (!url.endsWith("/")) {
+      url = url + "/";
+    }
+    log.info("Using {} api path {} (Override with -D{}=<url>)", name, url, property);
+    return url;
+  }
+
   private String optionUrl(String name, String defaultValue) {
     String property = "sentinel." + name + ".url";
     String url = System.getProperty(property, defaultValue);
@@ -231,7 +244,7 @@ public class SystemDefinitions {
                 .url(optionUrlArgonaut("https://argonaut.lighthouse.va.gov"))
                 .port(443)
                 .accessToken(magicAccessToken())
-                .apiPath("/api/")
+                .apiPath(optionApiPath("argonaut", "/api/"))
                 .build())
         .cdwIds(prodAndQaIds())
         .build();
@@ -287,7 +300,7 @@ public class SystemDefinitions {
                 .url(optionUrlArgonaut("https://qa-argonaut.lighthouse.va.gov"))
                 .port(443)
                 .accessToken(magicAccessToken())
-                .apiPath("/api/")
+                .apiPath(optionApiPath("argonaut", "/api/"))
                 .build())
         .cdwIds(prodAndQaIds())
         .build();
@@ -317,7 +330,7 @@ public class SystemDefinitions {
                 .url(optionUrlArgonaut("https://staging-argonaut.lighthouse.va.gov"))
                 .port(443)
                 .accessToken(magicAccessToken())
-                .apiPath("/api/")
+                .apiPath(optionApiPath("argonaut", "/api/"))
                 .build())
         .build();
   }

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/ResourceDiscovery.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/ResourceDiscovery.java
@@ -116,6 +116,7 @@ public class ResourceDiscovery {
    * described in the class documentation.
    */
   public List<String> queries() {
+    log.info("Discovering {}", url);
     Conformance conformanceStatement =
         RestAssured.given()
             .relaxedHTTPSValidation()

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/CdwCrawlerTest.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/CdwCrawlerTest.java
@@ -35,7 +35,7 @@ public class CdwCrawlerTest {
     log.info("Access token is specified");
 
     ResourceDiscovery discovery =
-        ResourceDiscovery.builder().patientId(patient).url(env.argonaut().url() + "/api").build();
+        ResourceDiscovery.builder().patientId(patient).url(env.argonaut().urlWithApiPath()).build();
     SummarizingResultCollector results =
         SummarizingResultCollector.wrap(
             new FileResultsCollector(new File("target/cdw-crawl-" + patient)));
@@ -65,7 +65,7 @@ public class CdwCrawlerTest {
         "Link replacement {} (Override with -Dsentinel.argonaut.url.replace=<url>)", replaceUrl);
     return UrlReplacementRequestQueue.builder()
         .replaceUrl(replaceUrl)
-        .withUrl(env.argonaut().url())
+        .withUrl(env.argonaut().urlWithApiPath())
         .requestQueue(new ConcurrentRequestQueue())
         .build();
   }

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/LabCrawlerTest.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/LabCrawlerTest.java
@@ -21,7 +21,7 @@ import org.junit.experimental.categories.Category;
 @Slf4j
 public class LabCrawlerTest {
 
-  private LabRobots robots = LabRobots.fromSystemProperties();
+  private final LabRobots robots = LabRobots.fromSystemProperties();
 
   private int crawl(String patient) {
     SystemDefinition env = Sentinel.get().system();
@@ -33,10 +33,11 @@ public class LabCrawlerTest {
     IdMeOauthRobot robot = robots.makeRobot(user);
     Swiggity.swooty(patient);
     assertThat(robot.token().accessToken()).isNotBlank();
+
     ResourceDiscovery discovery =
         ResourceDiscovery.builder()
             .patientId(robot.token().patient())
-            .url("https://dev-api.va.gov/services/argonaut/v0")
+            .url(env.argonaut().urlWithApiPath())
             .build();
     SummarizingResultCollector results =
         SummarizingResultCollector.wrap(
@@ -82,7 +83,7 @@ public class LabCrawlerTest {
         "Link replacement {} (Override with -Dsentinel.argonaut.url.replace=<url>)", replaceUrl);
     return UrlReplacementRequestQueue.builder()
         .replaceUrl(replaceUrl)
-        .withUrl(env.argonaut().url())
+        .withUrl(env.argonaut().urlWithApiPath())
         .requestQueue(new ConcurrentRequestQueue())
         .build();
   }

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/LabCrawlerTest.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/LabCrawlerTest.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import gov.va.health.api.sentinel.IdMeOauthRobot.Configuration.UserCredentials;
+import gov.va.health.api.sentinel.LabRobots.SmartOnFhirUrls;
 import gov.va.health.api.sentinel.categories.Manual;
 import gov.va.health.api.sentinel.crawler.ConcurrentRequestQueue;
 import gov.va.health.api.sentinel.crawler.Crawler;
@@ -30,7 +31,8 @@ public class LabCrawlerTest {
             .id(patient)
             .password(System.getProperty("lab.user-password"))
             .build();
-    IdMeOauthRobot robot = robots.makeRobot(user);
+    IdMeOauthRobot robot =
+        robots.makeRobot(user, new SmartOnFhirUrls(env.argonaut().urlWithApiPath()));
     Swiggity.swooty(patient);
     assertThat(robot.token().accessToken()).isNotBlank();
 


### PR DESCRIPTION
Support blue/green crawling in Prod-like and Lab-like environments.

Changed or new properties
```
# Base URL for the Argo you want to test
-Dsentinel.argonaut.url=https://dev-api.va.gov
# API path for the Argo you want to test 
-Dsentinel.argonaut.api-path=/services/argonaut/v0/ 
# The portion of the links you want to replace with url + path from above
-Dsentinel.argonaut.url.replace=https://dev-api.va.gov/services/argonaut/v0/
```