### PR TITLE
remove trailing slash if present from basepaths

### DIFF
--- a/sentinel/src/main/java/gov/va/health/api/sentinel/SystemDefinitions.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/SystemDefinitions.java
@@ -200,6 +200,9 @@ public class SystemDefinitions {
   private String optionUrl(String name, String defaultValue) {
     String property = "sentinel." + name + ".url";
     String url = System.getProperty(property, defaultValue);
+    if (url.endsWith("/")) {
+      url = url.substring(0, url.length() - 1);
+    }
     log.info("Using {} url {} (Override with -D{}=<url>)", name, url, property);
     return url;
   }


### PR DESCRIPTION
Related story: https://vasdvp.atlassian.net/browse/API-883

Removed trailing slashes from basepaths if present, as API paths will always have preceding slashes. 