### PR TITLE
Task/API-882 Edit url replacement request queue builder to be agnostic about /s

### DIFF
--- a/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/UrlReplacementRequestQueue.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/UrlReplacementRequestQueue.java
@@ -18,10 +18,10 @@ public class UrlReplacementRequestQueue implements RequestQueue {
   @Builder
   UrlReplacementRequestQueue(String replaceUrl, String withUrl, RequestQueue requestQueue) {
     if (isBlank(withUrl)) {
-      throw new IllegalStateException("withUrl not specified.");
+      throw new IllegalArgumentException("withUrl not specified.");
     }
     if (isBlank(replaceUrl)) {
-      throw new IllegalStateException("replaceUrl not specified.");
+      throw new IllegalArgumentException("replaceUrl not specified.");
     }
     this.replaceUrl = replaceUrl.endsWith("/") ? replaceUrl : replaceUrl + "/";
     this.withUrl = withUrl.endsWith("/") ? withUrl : withUrl + "/";

--- a/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/UrlReplacementRequestQueue.java
+++ b/sentinel/src/main/java/gov/va/health/api/sentinel/crawler/UrlReplacementRequestQueue.java
@@ -23,8 +23,8 @@ public class UrlReplacementRequestQueue implements RequestQueue {
     if (isBlank(replaceUrl)) {
       throw new IllegalStateException("replaceUrl not specified.");
     }
-    this.replaceUrl = replaceUrl;
-    this.withUrl = withUrl;
+    this.replaceUrl = replaceUrl.endsWith("/") ? replaceUrl : replaceUrl + "/";
+    this.withUrl = withUrl.endsWith("/") ? withUrl : withUrl + "/";
     this.requestQueue = requestQueue;
   }
 

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/crawler/UrlReplacementRequestQueueTest.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/crawler/UrlReplacementRequestQueueTest.java
@@ -100,6 +100,21 @@ public class UrlReplacementRequestQueueTest {
   }
 
   @Test
+  public void replaceUrlAppendsSlash() {
+    UrlReplacementRequestQueue appendToReplaceUrlRq =
+        UrlReplacementRequestQueue.builder()
+            .replaceUrl("https://dev-api.va.gov/services/argonaut/v0")
+            .withUrl("https://staging-argonaut.lighthouse.va.gov/api/")
+            .requestQueue(new ConcurrentResourceBalancingRequestQueue())
+            .build();
+    appendToReplaceUrlRq.add(
+        "https://dev-api.va.gov/services/argonaut/v0/AllergyIntolerance/3be00408-b0ff-598d-8ba1-1e0bbfb02b99");
+    String expected =
+        "https://staging-argonaut.lighthouse.va.gov/api/AllergyIntolerance/3be00408-b0ff-598d-8ba1-1e0bbfb02b99";
+    assertThat(appendToReplaceUrlRq.next()).isEqualTo(expected);
+  }
+
+  @Test
   public void theSameItemCannotBeAddedToTheQueueTwice() {
     rq.add("a");
     rq.add("b");
@@ -115,5 +130,20 @@ public class UrlReplacementRequestQueueTest {
     assertThat(rq.hasNext()).isTrue();
     assertThat(rq.next()).isEqualTo("c");
     assertThat(rq.hasNext()).isFalse();
+  }
+
+  @Test
+  public void withUrlAppendsSlash() {
+    UrlReplacementRequestQueue appendToWithUrlRq =
+        UrlReplacementRequestQueue.builder()
+            .replaceUrl("https://dev-api.va.gov/services/argonaut/v0/")
+            .withUrl("https://staging-argonaut.lighthouse.va.gov/api")
+            .requestQueue(new ConcurrentResourceBalancingRequestQueue())
+            .build();
+    appendToWithUrlRq.add(
+        "https://dev-api.va.gov/services/argonaut/v0/AllergyIntolerance/3be00408-b0ff-598d-8ba1-1e0bbfb02b99");
+    String expected =
+        "https://staging-argonaut.lighthouse.va.gov/api/AllergyIntolerance/3be00408-b0ff-598d-8ba1-1e0bbfb02b99";
+    assertThat(appendToWithUrlRq.next()).isEqualTo(expected);
   }
 }

--- a/sentinel/src/test/java/gov/va/health/api/sentinel/crawler/UrlReplacementRequestQueueTest.java
+++ b/sentinel/src/test/java/gov/va/health/api/sentinel/crawler/UrlReplacementRequestQueueTest.java
@@ -12,7 +12,7 @@ public class UrlReplacementRequestQueueTest {
           .requestQueue(new ConcurrentResourceBalancingRequestQueue())
           .build();
 
-  @Test(expected = IllegalStateException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void emptyBaseUrlThrowsIllegalStateException() {
     UrlReplacementRequestQueue emptyBaseUrl =
         UrlReplacementRequestQueue.builder()
@@ -23,7 +23,7 @@ public class UrlReplacementRequestQueueTest {
     emptyBaseUrl.add("Empty forceUrl");
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void emptyForceUrlThrowsIllegalStateException() {
     UrlReplacementRequestQueue emptyBaseUrl =
         UrlReplacementRequestQueue.builder()
@@ -77,7 +77,7 @@ public class UrlReplacementRequestQueueTest {
     assertThat(rq.hasNext()).isFalse();
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void nullBaseUrlThrowsIllegalStateException() {
     UrlReplacementRequestQueue emptyBaseUrl =
         UrlReplacementRequestQueue.builder()
@@ -88,7 +88,7 @@ public class UrlReplacementRequestQueueTest {
     emptyBaseUrl.add("Empty baseUrl");
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void nullForceUrlThrowsIllegalStateException() {
     UrlReplacementRequestQueue emptyBaseUrl =
         UrlReplacementRequestQueue.builder()


### PR DESCRIPTION
Make /'s agnostic in sentinel crawlers to prevent missing or double /'s in url replacement.